### PR TITLE
aabq.4 part 2: blocking CI for the profile/team/Library e2e

### DIFF
--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -1,0 +1,80 @@
+name: CLI e2e (profile/team/Library)
+
+# Real-stack profile/team/Library e2e net (default-aabq.4, part 2). Brings up the
+# awid + aweb + Library docker-compose stack from source, seeds the engineering
+# pack, and runs the AW_E2E suite driving the REAL aw binary against the live
+# services. This is the blocking gate that catches the materialize/team/Library
+# regressions hermetic unit tests miss (the class of P0s that shipped on
+# green-plus-reviewer-ACK).
+#
+# It needs the two sibling checkouts the stack builds from / seeds:
+#   awebai/library      (public) -> Library service build context
+#   awebai/blueprints   (public) -> the aweb.engineering pack the seed publishes
+# Both are public, so the default GITHUB_TOKEN can clone them.
+
+on:
+  pull_request:
+    paths:
+      - "cli/**"
+      - "docker-compose.e2e.yml"
+      - "scripts/e2e-library-stack.sh"
+      - "scripts/e2e/**"
+      - "awid/**"
+      - "server/**"
+      - ".github/workflows/cli-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - "docker-compose.e2e.yml"
+      - "scripts/e2e-library-stack.sh"
+      - "scripts/e2e/**"
+      - "awid/**"
+      - "server/**"
+      - ".github/workflows/cli-e2e.yml"
+
+concurrency:
+  group: cli-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-e2e:
+    name: CLI real-stack e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout aweb
+        uses: actions/checkout@v4
+        with:
+          path: aweb
+
+      - name: Checkout library
+        uses: actions/checkout@v4
+        with:
+          repository: awebai/library
+          path: library
+
+      - name: Checkout blueprints
+        uses: actions/checkout@v4
+        with:
+          repository: awebai/blueprints
+          path: blueprints
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: aweb/cli/go/go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run CLI real-stack e2e
+        working-directory: aweb
+        env:
+          # The stack auto-resolves siblings, but in CI the repos are checked out
+          # under explicit paths, so point at them directly.
+          LIBRARY_E2E_LIBRARY_CONTEXT: ${{ github.workspace }}/library
+          LIBRARY_E2E_BLUEPRINT_SRC: ${{ github.workspace }}/blueprints/engineering
+        run: make -C cli e2e

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -70,6 +70,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      # GitHub runners share IPs and hit Docker Hub's anonymous pull limits, which
+      # fails the stack's postgres/redis pulls and the python:3.12-slim base in the
+      # awid/aweb/library builds. Route docker.io through Google's pull-through
+      # mirror (no auth, no rate limit) so every docker.io pull is covered.
+      - name: Route Docker Hub pulls through a mirror
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Run CLI real-stack e2e
         working-directory: aweb
         env:

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -43,17 +43,21 @@ teardown() {
 }
 trap teardown EXIT
 
-echo "=== Bring up + seed the stack ==="
-"$STACK" up
-"$STACK" seed
-
+# Build aw first and drive the seed with it, so the run never depends on an `aw`
+# already being on PATH (it is not in CI; on a dev box a stray one might be the
+# wrong version).
 echo "=== Build the aw binary ==="
 make -C "$CLI_DIR/go" build
+AW_BIN="$CLI_DIR/go/aw"
+
+echo "=== Bring up + seed the stack ==="
+"$STACK" up
+AW_BIN="$AW_BIN" "$STACK" seed
 
 echo "=== Run the real-stack Go e2e suite (AW_E2E=1, -tags e2e) ==="
 cd "$CLI_DIR/go"
 AW_E2E=1 \
-AW_BIN="$CLI_DIR/go/aw" \
+AW_BIN="$AW_BIN" \
 AWEB_URL="$AWEB_URL" \
 AWID_REGISTRY_URL="$AWID_URL" \
 LIBRARY_E2E_LIBRARY_URL="$LIBRARY_URL" \


### PR DESCRIPTION
Adds `.github/workflows/cli-e2e.yml` — the blocking CI gate that brings up the awid + aweb + Library docker-compose stack from source, seeds the engineering pack, and runs the `AW_E2E` real-binary suite (`make -C cli e2e`). Checks out the public sibling repos `awebai/library` + `awebai/blueprints`.

Also fixes `cli/scripts/e2e.sh` to build `aw` before seeding and drive the seed with the built binary (no dependency on an `aw` on PATH — which CI does not have).

Held until `awebai/blueprints` was published; now live, so this PR run exercises the real gate. Part 1 (release-gate wiring in `make ship`) already landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)