### PR TITLE
test(aw): eliminate remaining handler races (aalx)

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -101,8 +101,14 @@ jobs:
 
   # Separate job because the race detector is the instrument that validates the
   # concurrency classes this audit found, and it must be able to fail on its own
-  # rather than being masked by an unrelated failure in the plain run. Scoped to
-  # the packages that hold concurrent code; no blanket exclusions within them.
+  # rather than being masked by an unrelated failure in the plain run.
+  #
+  # Runs over ./... rather than a package list. A hand-maintained list silently
+  # stops covering the moment someone adds concurrent code to a package not on
+  # it, and nothing notices — the same drift that let stale inventories rot in
+  # default-aajc.16. The four goroutine-launching packages that the original
+  # list omitted (the root package, chat, a2agw, cmd/aweb-a2a-gw) were measured
+  # race-clean before widening, so this costs coverage nothing (default-aalx).
   go-race:
     runs-on: ubuntu-latest
     steps:
@@ -114,4 +120,4 @@ jobs:
 
       - name: Race detector
         working-directory: cli/go
-        run: go test -race ./awid/ ./run/ ./cmd/aw/ ./internal/conformance/ -count=1
+        run: go test -race ./... -count=1

--- a/cli/go/cmd/aw/aw_test.go
+++ b/cli/go/cmd/aw/aw_test.go
@@ -67,6 +67,34 @@ func newLocalHTTPServer(t *testing.T, handler http.Handler) *httptest.Server {
 // done right (default-aajc.15).
 func newLocalHTTPServerWithURL(t *testing.T, build func(url string) http.Handler) *httptest.Server {
 	t.Helper()
+	return newHTTPTestServerWithURL(t, func(url string) http.Handler {
+		handler := build(url)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// aw probes for aweb by calling GET /v1/agents/heartbeat on candidate bases.
+			// Return any non-404 to indicate "endpoint exists" without side effects.
+			// Only intercept GET; POST is the actual heartbeat and should reach the inner handler.
+			if r.Method == http.MethodGet && (r.URL.Path == "/v1/agents/heartbeat" || r.URL.Path == "/api/v1/agents/heartbeat") {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			handler.ServeHTTP(w, r)
+		})
+	})
+}
+
+func newLocalHTTPServerHandlerWithURL(t *testing.T, handler func(url string, w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return newLocalHTTPServerWithURL(t, func(url string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler(url, w, r)
+		})
+	})
+}
+
+// newHTTPTestServerWithURL is the plain httptest.NewServer equivalent for
+// handlers that need their own immutable URL before the server starts.
+func newHTTPTestServerWithURL(t *testing.T, build func(url string) http.Handler) *httptest.Server {
+	t.Helper()
 
 	l, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
@@ -75,20 +103,9 @@ func newLocalHTTPServerWithURL(t *testing.T, build func(url string) http.Handler
 	// Matches how httptest derives Server.URL for a non-TLS server, so the
 	// handler sees exactly the URL callers will use.
 	url := "http://" + l.Addr().String()
-	handler := build(url)
-	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// aw probes for aweb by calling GET /v1/agents/heartbeat on candidate bases.
-		// Return any non-404 to indicate "endpoint exists" without side effects.
-		// Only intercept GET; POST is the actual heartbeat and should reach the inner handler.
-		if r.Method == http.MethodGet && (r.URL.Path == "/v1/agents/heartbeat" || r.URL.Path == "/api/v1/agents/heartbeat") {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-		handler.ServeHTTP(w, r)
-	})
 	srv := &httptest.Server{
 		Listener: l,
-		Config:   &http.Server{Handler: wrapped},
+		Config:   &http.Server{Handler: build(url)},
 	}
 	srv.Start()
 	if srv.URL != url {
@@ -96,6 +113,15 @@ func newLocalHTTPServerWithURL(t *testing.T, build func(url string) http.Handler
 	}
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func newHTTPTestServerHandlerWithURL(t *testing.T, handler func(url string, w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return newHTTPTestServerWithURL(t, func(url string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler(url, w, r)
+		})
+	})
 }
 
 // extractJSON finds the first JSON object in mixed output (e.g. from

--- a/cli/go/cmd/aw/claim_human_test.go
+++ b/cli/go/cmd/aw/claim_human_test.go
@@ -34,35 +34,37 @@ func TestClaimHumanCommandSendsSignedOnboardingRequest(t *testing.T) {
 	var gotAuth string
 	var gotTimestamp string
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   "https://api.awid.ai",
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			gotAuth = strings.TrimSpace(r.Header.Get("Authorization"))
-			gotTimestamp = strings.TrimSpace(r.Header.Get("X-AWEB-Timestamp"))
-			var err error
-			gotBodyBytes, err = io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   "https://api.awid.ai",
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				gotAuth = strings.TrimSpace(r.Header.Get("Authorization"))
+				gotTimestamp = strings.TrimSpace(r.Header.Get("X-AWEB-Timestamp"))
+				var err error
+				gotBodyBytes, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal(gotBodyBytes, &gotBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "verification_sent",
+					"email":  "alice@example.com",
+				})
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			if err := json.Unmarshal(gotBodyBytes, &gotBody); err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "verification_sent",
-				"email":  "alice@example.com",
-			})
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -122,35 +124,37 @@ func TestClaimHumanCommandFallsBackWithoutIdentityFile(t *testing.T) {
 	var gotAuth string
 	var gotTimestamp string
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   "https://api.awid.ai",
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			gotAuth = strings.TrimSpace(r.Header.Get("Authorization"))
-			gotTimestamp = strings.TrimSpace(r.Header.Get("X-AWEB-Timestamp"))
-			var err error
-			gotBodyBytes, err = io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   "https://api.awid.ai",
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				gotAuth = strings.TrimSpace(r.Header.Get("Authorization"))
+				gotTimestamp = strings.TrimSpace(r.Header.Get("X-AWEB-Timestamp"))
+				var err error
+				gotBodyBytes, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal(gotBodyBytes, &gotBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "verification_sent",
+					"email":  "alice@example.com",
+				})
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			if err := json.Unmarshal(gotBodyBytes, &gotBody); err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "verification_sent",
-				"email":  "alice@example.com",
-			})
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -213,25 +217,27 @@ func TestClaimHumanCommandPrintsAlreadyAttachedWithoutEmailClaim(t *testing.T) {
 	stableID := awid.ComputeStableID(pub)
 
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   "https://api.awid.ai",
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "already_attached",
-				"email":  "alice@example.com",
-			})
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   "https://api.awid.ai",
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "already_attached",
+					"email":  "alice@example.com",
+				})
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -270,28 +276,30 @@ func TestClaimHumanCommandUsesExplicitUsernameForBYODIdentity(t *testing.T) {
 
 	var gotBody map[string]any
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   "https://api.awid.ai",
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   "https://api.awid.ai",
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "verification_sent",
+					"email":  "alice@example.com",
+				})
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "verification_sent",
-				"email":  "alice@example.com",
-			})
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -326,28 +334,30 @@ func TestClaimHumanCommandAllowsUsernameOverride(t *testing.T) {
 
 	var gotBody map[string]any
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   "https://api.awid.ai",
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   "https://api.awid.ai",
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "verification_sent",
+					"email":  "alice@example.com",
+				})
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "verification_sent",
-				"email":  "alice@example.com",
-			})
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cli/go/cmd/aw/connect_test.go
+++ b/cli/go/cmd/aw/connect_test.go
@@ -37,98 +37,100 @@ func TestConnectBootstrapGlobal(t *testing.T) {
 		onboardingURL   string
 	)
 
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   onboardingURL,
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatal(err)
-			}
-			globalDidAW, _ = payload["did_aw"].(string)
-			globalDidKey, _ = payload["new_did_key"].(string)
-			for _, field := range []string{"did_key", "server", "address", "handle"} {
-				if _, ok := payload[field]; ok {
-					t.Fatalf("register_did payload unexpectedly carried %q", field)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   onboardingURL,
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
 				}
-			}
-			didRegistered = true
-			_ = json.NewEncoder(w).Encode(map[string]any{"registered": true})
-		case r.Method == http.MethodGet && globalDidAW != "" && r.URL.Path == "/v1/did/"+globalDidAW+"/full":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"did_aw":          globalDidAW,
-				"current_did_key": globalDidKey,
-				"created_at":      "2026-04-07T00:00:00Z",
-				"updated_at":      "2026-04-07T00:00:00Z",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
-			redeemAuth = strings.TrimSpace(r.Header.Get("Authorization"))
-			redeemTimestamp = strings.TrimSpace(r.Header.Get("X-AWEB-Timestamp"))
-			var err error
-			redeemBodyBytes, err = io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := json.Unmarshal(redeemBodyBytes, &redeemBody); err != nil {
-				t.Fatal(err)
-			}
+				globalDidAW, _ = payload["did_aw"].(string)
+				globalDidKey, _ = payload["new_did_key"].(string)
+				for _, field := range []string{"did_key", "server", "address", "handle"} {
+					if _, ok := payload[field]; ok {
+						t.Fatalf("register_did payload unexpectedly carried %q", field)
+					}
+				}
+				didRegistered = true
+				_ = json.NewEncoder(w).Encode(map[string]any{"registered": true})
+			case r.Method == http.MethodGet && globalDidAW != "" && r.URL.Path == "/v1/did/"+globalDidAW+"/full":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"did_aw":          globalDidAW,
+					"current_did_key": globalDidKey,
+					"created_at":      "2026-04-07T00:00:00Z",
+					"updated_at":      "2026-04-07T00:00:00Z",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
+				redeemAuth = strings.TrimSpace(r.Header.Get("Authorization"))
+				redeemTimestamp = strings.TrimSpace(r.Header.Get("X-AWEB-Timestamp"))
+				var err error
+				redeemBodyBytes, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal(redeemBodyBytes, &redeemBody); err != nil {
+					t.Fatal(err)
+				}
 
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:          "default:juanre.aweb.ai",
-				MemberDIDKey:  globalDidKey,
-				MemberDIDAW:   globalDidAW,
-				MemberAddress: "juanre.aweb.ai/laptop-agent",
-				Alias:         "laptop-agent",
-				Lifetime:      awid.LifetimePersistent,
-			})
-			if err != nil {
-				t.Fatal(err)
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:          "default:juanre.aweb.ai",
+					MemberDIDKey:  globalDidKey,
+					MemberDIDAW:   globalDidAW,
+					MemberAddress: "juanre.aweb.ai/laptop-agent",
+					Alias:         "laptop-agent",
+					Lifetime:      awid.LifetimePersistent,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encoded, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"certificate":    encoded,
+					"team_id":        "default:juanre.aweb.ai",
+					"lifetime":       "persistent",
+					"alias":          "laptop-agent",
+					"did_aw":         globalDidAW,
+					"member_address": "juanre.aweb.ai/laptop-agent",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
+				if !didRegistered {
+					t.Fatal("bootstrap-redeem ran before DID registration")
+				}
+				if !strings.HasPrefix(strings.TrimSpace(r.Header.Get("Authorization")), "DIDKey ") {
+					t.Fatalf("connect auth=%q", r.Header.Get("Authorization"))
+				}
+				if strings.TrimSpace(r.Header.Get("X-AWID-Team-Certificate")) == "" {
+					t.Fatal("missing team certificate header")
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"team_id":      "default:juanre.aweb.ai",
+					"alias":        "laptop-agent",
+					"agent_id":     "agent-1",
+					"workspace_id": "ws-1",
+					"repo_id":      "",
+					"team_did_key": teamDIDKey,
+				})
+			case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/did/") && strings.HasSuffix(r.URL.Path, "/encryption-key"):
+				writeRegistryEncryptionKeyAssertionForTest(t, w, r)
+			case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
+				writePublishEncryptionKeyResponseForTest(t, w, "agent-1", "default:juanre.aweb.ai", "laptop-agent")
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			encoded, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"certificate":    encoded,
-				"team_id":        "default:juanre.aweb.ai",
-				"lifetime":       "persistent",
-				"alias":          "laptop-agent",
-				"did_aw":         globalDidAW,
-				"member_address": "juanre.aweb.ai/laptop-agent",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
-			if !didRegistered {
-				t.Fatal("bootstrap-redeem ran before DID registration")
-			}
-			if !strings.HasPrefix(strings.TrimSpace(r.Header.Get("Authorization")), "DIDKey ") {
-				t.Fatalf("connect auth=%q", r.Header.Get("Authorization"))
-			}
-			if strings.TrimSpace(r.Header.Get("X-AWID-Team-Certificate")) == "" {
-				t.Fatal("missing team certificate header")
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"team_id":      "default:juanre.aweb.ai",
-				"alias":        "laptop-agent",
-				"agent_id":     "agent-1",
-				"workspace_id": "ws-1",
-				"repo_id":      "",
-				"team_did_key": teamDIDKey,
-			})
-		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/did/") && strings.HasSuffix(r.URL.Path, "/encryption-key"):
-			writeRegistryEncryptionKeyAssertionForTest(t, w, r)
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
-			writePublishEncryptionKeyResponseForTest(t, w, "agent-1", "default:juanre.aweb.ai", "laptop-agent")
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -279,61 +281,63 @@ func TestConnectBootstrapLocal(t *testing.T) {
 
 	var redeemBody map[string]any
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   onboardingURL,
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
-			t.Fatal("local connect should not register did:aw")
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
-			data, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   onboardingURL,
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
+				t.Fatal("local connect should not register did:aw")
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
+				data, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal(data, &redeemBody); err != nil {
+					t.Fatal(err)
+				}
+				didKey, _ := redeemBody["did_key"].(string)
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:         "default:juanre.aweb.ai",
+					MemberDIDKey: didKey,
+					Alias:        "ci-runner-01",
+					Lifetime:     awid.LifetimeEphemeral,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encoded, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"certificate": encoded,
+					"team_id":     "default:juanre.aweb.ai",
+					"lifetime":    "ephemeral",
+					"alias":       "ci-runner-01",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"team_id":      "default:juanre.aweb.ai",
+					"alias":        "ci-runner-01",
+					"agent_id":     "agent-2",
+					"workspace_id": "ws-2",
+					"repo_id":      "",
+					"team_did_key": teamDIDKey,
+				})
+			case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
+				writePublishEncryptionKeyResponseForTest(t, w, "agent-2", "default:juanre.aweb.ai", "ci-runner-01")
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			if err := json.Unmarshal(data, &redeemBody); err != nil {
-				t.Fatal(err)
-			}
-			didKey, _ := redeemBody["did_key"].(string)
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:         "default:juanre.aweb.ai",
-				MemberDIDKey: didKey,
-				Alias:        "ci-runner-01",
-				Lifetime:     awid.LifetimeEphemeral,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			encoded, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"certificate": encoded,
-				"team_id":     "default:juanre.aweb.ai",
-				"lifetime":    "ephemeral",
-				"alias":       "ci-runner-01",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"team_id":      "default:juanre.aweb.ai",
-				"alias":        "ci-runner-01",
-				"agent_id":     "agent-2",
-				"workspace_id": "ws-2",
-				"repo_id":      "",
-				"team_did_key": teamDIDKey,
-			})
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
-			writePublishEncryptionKeyResponseForTest(t, w, "agent-2", "default:juanre.aweb.ai", "ci-runner-01")
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -372,23 +376,25 @@ func TestConnectBootstrapMapsConflict(t *testing.T) {
 	t.Parallel()
 
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   onboardingURL,
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
-			w.WriteHeader(http.StatusConflict)
-			_, _ = io.WriteString(w, `{"detail":"token already consumed"}`)
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   onboardingURL,
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
+				w.WriteHeader(http.StatusConflict)
+				_, _ = io.WriteString(w, `{"detail":"token already consumed"}`)
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -444,72 +450,74 @@ func TestConnectBootstrapUsesDiscoveryAwebURLForConnect(t *testing.T) {
 		}
 	}))
 
-	onboardingServer := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       awebServer.URL,
-				"registry_url":   onboardingURL,
-				"version":        "1.7.0",
-				"features":       []string{"bootstrap_tokens"},
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatal(err)
+	onboardingServer := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       awebServer.URL,
+					"registry_url":   onboardingURL,
+					"version":        "1.7.0",
+					"features":       []string{"bootstrap_tokens"},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
+				}
+				globalDidAW, _ = payload["did_aw"].(string)
+				globalDidKey, _ = payload["new_did_key"].(string)
+				_ = json.NewEncoder(w).Encode(map[string]any{"registered": true})
+			case r.Method == http.MethodGet && globalDidAW != "" && r.URL.Path == "/v1/did/"+globalDidAW+"/full":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"did_aw":          globalDidAW,
+					"current_did_key": globalDidKey,
+					"created_at":      "2026-04-07T00:00:00Z",
+					"updated_at":      "2026-04-07T00:00:00Z",
+				})
+			case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/did/") && strings.HasSuffix(r.URL.Path, "/encryption-key"):
+				var assertion awid.EncryptionKeyAssertion
+				if err := json.NewDecoder(r.Body).Decode(&assertion); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(assertion)
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
+				var redeemBody map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&redeemBody); err != nil {
+					t.Fatal(err)
+				}
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:          "default:juanre.aweb.ai",
+					MemberDIDKey:  globalDidKey,
+					MemberDIDAW:   globalDidAW,
+					MemberAddress: "juanre.aweb.ai/laptop-agent",
+					Alias:         "laptop-agent",
+					Lifetime:      awid.LifetimePersistent,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encoded, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"certificate":    encoded,
+					"team_id":        "default:juanre.aweb.ai",
+					"lifetime":       "persistent",
+					"alias":          "laptop-agent",
+					"did_aw":         globalDidAW,
+					"member_address": "juanre.aweb.ai/laptop-agent",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
+				t.Fatal("connect should use discovered aweb_url, not the bootstrap base URL")
+			default:
+				t.Fatalf("unexpected bootstrap service request %s %s", r.Method, r.URL.Path)
 			}
-			globalDidAW, _ = payload["did_aw"].(string)
-			globalDidKey, _ = payload["new_did_key"].(string)
-			_ = json.NewEncoder(w).Encode(map[string]any{"registered": true})
-		case r.Method == http.MethodGet && globalDidAW != "" && r.URL.Path == "/v1/did/"+globalDidAW+"/full":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"did_aw":          globalDidAW,
-				"current_did_key": globalDidKey,
-				"created_at":      "2026-04-07T00:00:00Z",
-				"updated_at":      "2026-04-07T00:00:00Z",
-			})
-		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/did/") && strings.HasSuffix(r.URL.Path, "/encryption-key"):
-			var assertion awid.EncryptionKeyAssertion
-			if err := json.NewDecoder(r.Body).Decode(&assertion); err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(assertion)
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/bootstrap-redeem":
-			var redeemBody map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&redeemBody); err != nil {
-				t.Fatal(err)
-			}
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:          "default:juanre.aweb.ai",
-				MemberDIDKey:  globalDidKey,
-				MemberDIDAW:   globalDidAW,
-				MemberAddress: "juanre.aweb.ai/laptop-agent",
-				Alias:         "laptop-agent",
-				Lifetime:      awid.LifetimePersistent,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			encoded, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"certificate":    encoded,
-				"team_id":        "default:juanre.aweb.ai",
-				"lifetime":       "persistent",
-				"alias":          "laptop-agent",
-				"did_aw":         globalDidAW,
-				"member_address": "juanre.aweb.ai/laptop-agent",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
-			t.Fatal("connect should use discovered aweb_url, not the bootstrap base URL")
-		default:
-			t.Fatalf("unexpected bootstrap service request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = onboardingServer.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cli/go/cmd/aw/hosted_signup_test.go
+++ b/cli/go/cmd/aw/hosted_signup_test.go
@@ -38,13 +38,13 @@ func TestInitGlobalCreatesSelfCustodialGlobalCLIIdentityAndSignsCloudRequest(t *
 	)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL + "/api",
-				"registry_url":   server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL + "/api",
+				"registry_url":   serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
 			var payload map[string]any
@@ -155,7 +155,7 @@ func TestInitGlobalCreatesSelfCustodialGlobalCLIIdentityAndSignsCloudRequest(t *
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -305,13 +305,13 @@ func TestInitSelfCustodialGlobalCLIThenAddWorktreeTwiceUsesStoredWorkspaceAPIKey
 	}
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
-				"registry_url":   server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
+				"registry_url":   serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
 			_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
@@ -381,7 +381,7 @@ func TestInitSelfCustodialGlobalCLIThenAddWorktreeTwiceUsesStoredWorkspaceAPIKey
 				Lifetime:     awid.LifetimeEphemeral,
 			})
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          alias,
 				"team_id":        teamID,
@@ -436,7 +436,7 @@ func TestInitSelfCustodialGlobalCLIThenAddWorktreeTwiceUsesStoredWorkspaceAPIKey
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
@@ -536,13 +536,13 @@ func TestInitSelfCustodialGlobalCLITreatsSameKeyAlreadyRegisteredAsSuccess(t *te
 	)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
-				"registry_url":   server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
+				"registry_url":   serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
 			_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
@@ -621,7 +621,7 @@ func TestInitSelfCustodialGlobalCLITreatsSameKeyAlreadyRegisteredAsSuccess(t *te
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -687,13 +687,13 @@ func TestInitLocalCLIWorkspaceOmitsGlobalIdentityFile(t *testing.T) {
 	)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
-				"registry_url":   server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
+				"registry_url":   serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
 			_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
@@ -748,7 +748,7 @@ func TestInitLocalCLIWorkspaceOmitsGlobalIdentityFile(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cli/go/cmd/aw/id_commands_test.go
+++ b/cli/go/cmd/aw/id_commands_test.go
@@ -1419,88 +1419,90 @@ func TestAwIDRotateKeyRotatesStandaloneIdentityAndUpdatesLocalState(t *testing.T
 	var rotated atomic.Bool
 	var seenPut atomic.Bool
 	var newDID string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/v1/did/" + stableID + "/key":
-			if r.Method != http.MethodGet {
-				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"did_aw":          stableID,
-				"current_did_key": oldDID,
-				"log_head":        didLogJSON(logHead),
-			})
-		case "/v1/did/" + stableID + "/full":
-			if r.Method != http.MethodGet {
-				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-			}
-			authDID := didFromRegistryAuthHeader(t, r)
-			currentDID := oldDID
-			if rotated.Load() {
-				currentDID = newDID
-				if authDID != newDID {
-					t.Fatalf("post-rotation auth did=%q want %q", authDID, newDID)
+	_ = newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		registryURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/v1/did/" + stableID + "/key":
+				if r.Method != http.MethodGet {
+					t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 				}
-			} else if authDID != oldDID {
-				t.Fatalf("pre-rotation auth did=%q want %q", authDID, oldDID)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"did_aw":          stableID,
-				"current_did_key": currentDID,
-				"created_at":      "2026-04-05T00:00:00Z",
-				"updated_at":      "2026-04-05T00:00:00Z",
-			})
-		case "/v1/did/" + stableID:
-			if r.Method != http.MethodPut {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"did_aw":          stableID,
+					"current_did_key": oldDID,
+					"log_head":        didLogJSON(logHead),
+				})
+			case "/v1/did/" + stableID + "/full":
+				if r.Method != http.MethodGet {
+					t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+				}
+				authDID := didFromRegistryAuthHeader(t, r)
+				currentDID := oldDID
+				if rotated.Load() {
+					currentDID = newDID
+					if authDID != newDID {
+						t.Fatalf("post-rotation auth did=%q want %q", authDID, newDID)
+					}
+				} else if authDID != oldDID {
+					t.Fatalf("pre-rotation auth did=%q want %q", authDID, oldDID)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"did_aw":          stableID,
+					"current_did_key": currentDID,
+					"created_at":      "2026-04-05T00:00:00Z",
+					"updated_at":      "2026-04-05T00:00:00Z",
+				})
+			case "/v1/did/" + stableID:
+				if r.Method != http.MethodPut {
+					t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+				}
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
+				}
+				if payload["operation"] != "rotate_key" {
+					t.Fatalf("operation=%v", payload["operation"])
+				}
+				if payload["authorized_by"] != oldDID {
+					t.Fatalf("authorized_by=%v", payload["authorized_by"])
+				}
+				if int(payload["seq"].(float64)) != 2 {
+					t.Fatalf("seq=%v", payload["seq"])
+				}
+				if payload["prev_entry_hash"] != logHead.EntryHash {
+					t.Fatalf("prev_entry_hash=%v want %s", payload["prev_entry_hash"], logHead.EntryHash)
+				}
+				newDID, _ = payload["new_did_key"].(string)
+				if strings.TrimSpace(newDID) == "" || newDID == oldDID {
+					t.Fatalf("new_did_key=%q", newDID)
+				}
+				entry := &awid.DidKeyEvidence{
+					Seq:            2,
+					Operation:      "rotate_key",
+					PreviousDIDKey: stringPtr(oldDID),
+					NewDIDKey:      newDID,
+					PrevEntryHash:  stringPtr(logHead.EntryHash),
+					StateHash:      payload["state_hash"].(string),
+					AuthorizedBy:   oldDID,
+					Timestamp:      payload["timestamp"].(string),
+				}
+				sig, err := base64.RawStdEncoding.DecodeString(payload["signature"].(string))
+				if err != nil {
+					t.Fatalf("decode signature: %v", err)
+				}
+				if !ed25519.Verify(oldPub, []byte(awid.CanonicalDidLogPayload(stableID, entry)), sig) {
+					t.Fatal("invalid rotation signature")
+				}
+				rotated.Store(true)
+				seenPut.Store(true)
+				_ = json.NewEncoder(w).Encode(map[string]any{"updated": true})
+			case "/v1/agents/heartbeat":
+				w.WriteHeader(http.StatusOK)
+			default:
 				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatal(err)
-			}
-			if payload["operation"] != "rotate_key" {
-				t.Fatalf("operation=%v", payload["operation"])
-			}
-			if payload["authorized_by"] != oldDID {
-				t.Fatalf("authorized_by=%v", payload["authorized_by"])
-			}
-			if int(payload["seq"].(float64)) != 2 {
-				t.Fatalf("seq=%v", payload["seq"])
-			}
-			if payload["prev_entry_hash"] != logHead.EntryHash {
-				t.Fatalf("prev_entry_hash=%v want %s", payload["prev_entry_hash"], logHead.EntryHash)
-			}
-			newDID, _ = payload["new_did_key"].(string)
-			if strings.TrimSpace(newDID) == "" || newDID == oldDID {
-				t.Fatalf("new_did_key=%q", newDID)
-			}
-			entry := &awid.DidKeyEvidence{
-				Seq:            2,
-				Operation:      "rotate_key",
-				PreviousDIDKey: stringPtr(oldDID),
-				NewDIDKey:      newDID,
-				PrevEntryHash:  stringPtr(logHead.EntryHash),
-				StateHash:      payload["state_hash"].(string),
-				AuthorizedBy:   oldDID,
-				Timestamp:      payload["timestamp"].(string),
-			}
-			sig, err := base64.RawStdEncoding.DecodeString(payload["signature"].(string))
-			if err != nil {
-				t.Fatalf("decode signature: %v", err)
-			}
-			if !ed25519.Verify(oldPub, []byte(awid.CanonicalDidLogPayload(stableID, entry)), sig) {
-				t.Fatal("invalid rotation signature")
-			}
-			rotated.Store(true)
-			seenPut.Store(true)
-			_ = json.NewEncoder(w).Encode(map[string]any{"updated": true})
-		case "/v1/agents/heartbeat":
-			w.WriteHeader(http.StatusOK)
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	registryURL = server.URL
+		})
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cli/go/cmd/aw/id_sign_request_test.go
+++ b/cli/go/cmd/aw/id_sign_request_test.go
@@ -509,14 +509,14 @@ func TestAwIDRequestTeamAuthSignsGlobalWorkspaceRequest(t *testing.T) {
 	stableID := awid.ComputeStableID(pub)
 	address := "acme.com/athena"
 
-	var sawStableID string
-	var sawCert *awid.TeamCertificate
-	var teamPub ed25519.PublicKey
+	var sawStableID guarded[string]
+	var sawCert guarded[*awid.TeamCertificate]
+	var teamPub guarded[ed25519.PublicKey]
 	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sawStableID = strings.TrimSpace(r.Header.Get("X-AWEB-DID-AW"))
-		sawCert = requireCertificateAuthForTest(t, r)
+		sawStableID.set(strings.TrimSpace(r.Header.Get("X-AWEB-DID-AW")))
+		sawCert.set(requireCertificateAuthForTest(t, r))
 		if err := verifyTeamAuthRequestFixtureForTest(r, []byte(`{"task":"global"}`), time.Now().UTC(), map[string]ed25519.PublicKey{
-			"backend:acme.com": teamPub,
+			"backend:acme.com": teamPub.get(),
 		}, nil); err != nil {
 			t.Fatalf("team-auth verifier rejected request: %v", err)
 		}
@@ -529,7 +529,7 @@ func TestAwIDRequestTeamAuthSignsGlobalWorkspaceRequest(t *testing.T) {
 	tmp := t.TempDir()
 	bin := filepath.Join(tmp, "aw")
 	buildAwBinary(t, ctx, bin)
-	teamPub = writeGlobalTeamSignedRequestWorkspaceForTest(t, tmp, server.URL, "backend:acme.com", "athena", did, stableID, address, priv)
+	teamPub.set(writeGlobalTeamSignedRequestWorkspaceForTest(t, tmp, server.URL, "backend:acme.com", "athena", did, stableID, address, priv))
 
 	run := exec.CommandContext(ctx, bin, "id", "request", "POST", server.URL+"/v1/awco/tasks",
 		"--team-auth",
@@ -543,14 +543,16 @@ func TestAwIDRequestTeamAuthSignsGlobalWorkspaceRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("global id request --team-auth failed: %v\n%s", err, string(out))
 	}
-	if sawStableID != stableID {
-		t.Fatalf("X-AWEB-DID-AW=%q want %q", sawStableID, stableID)
+	gotStableID := sawStableID.get()
+	if gotStableID != stableID {
+		t.Fatalf("X-AWEB-DID-AW=%q want %q", gotStableID, stableID)
 	}
-	if sawCert.MemberDIDKey != did || sawCert.MemberDIDAW != stableID || sawCert.MemberAddress != address {
-		t.Fatalf("certificate identity fields=%+v", sawCert)
+	gotCert := sawCert.get()
+	if gotCert.MemberDIDKey != did || gotCert.MemberDIDAW != stableID || gotCert.MemberAddress != address {
+		t.Fatalf("certificate identity fields=%+v", gotCert)
 	}
-	if sawCert.IdentityScope != awid.IdentityModeGlobal {
-		t.Fatalf("certificate identity_scope=%q want global", sawCert.IdentityScope)
+	if gotCert.IdentityScope != awid.IdentityModeGlobal {
+		t.Fatalf("certificate identity_scope=%q want global", gotCert.IdentityScope)
 	}
 }
 

--- a/cli/go/cmd/aw/id_team_test.go
+++ b/cli/go/cmd/aw/id_team_test.go
@@ -3753,9 +3753,13 @@ func TestTeamAddMemberByDIDIssuesLocalCertificate(t *testing.T) {
 func TestTeamAddMemberByDIDIssuesGlobalCertificateWhenStableFieldsProvided(t *testing.T) {
 	t.Parallel()
 
-	var registeredCert map[string]any
-	var memberDID string
+	memberPub, _, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	memberDID := awid.ComputeDIDKey(memberPub)
 	memberDIDAW := "did:aw:alice"
+	var registeredCert guarded[map[string]any]
 	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/namespaces/acme.com/addresses/alice":
@@ -3769,9 +3773,11 @@ func TestTeamAddMemberByDIDIssuesGlobalCertificateWhenStableFieldsProvided(t *te
 				"created_at":      "2026-04-06T00:00:00Z",
 			})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/certificates"):
-			if err := json.NewDecoder(r.Body).Decode(&registeredCert); err != nil {
+			var cert map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&cert); err != nil {
 				t.Fatal(err)
 			}
+			registeredCert.set(cert)
 			w.WriteHeader(http.StatusCreated)
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
@@ -3790,12 +3796,6 @@ func TestTeamAddMemberByDIDIssuesGlobalCertificateWhenStableFieldsProvided(t *te
 		t.Fatal(err)
 	}
 	writeTeamKeyForTest(t, tmp, "acme.com", "backend", teamKey)
-
-	memberPub, _, err := awid.GenerateKeypair()
-	if err != nil {
-		t.Fatal(err)
-	}
-	memberDID = awid.ComputeDIDKey(memberPub)
 
 	run := exec.CommandContext(ctx, bin, "id", "team", "add-member",
 		"--team", "backend",
@@ -3823,17 +3823,18 @@ func TestTeamAddMemberByDIDIssuesGlobalCertificateWhenStableFieldsProvided(t *te
 	if got["member_address"] != "acme.com/alice" {
 		t.Fatalf("member_address=%v", got["member_address"])
 	}
-	if registeredCert["member_did_key"] != memberDID {
-		t.Fatalf("registry cert member_did_key=%v", registeredCert["member_did_key"])
+	gotCert := registeredCert.get()
+	if gotCert["member_did_key"] != memberDID {
+		t.Fatalf("registry cert member_did_key=%v", gotCert["member_did_key"])
 	}
-	if registeredCert["member_did_aw"] != memberDIDAW {
-		t.Fatalf("registry cert member_did_aw=%v", registeredCert["member_did_aw"])
+	if gotCert["member_did_aw"] != memberDIDAW {
+		t.Fatalf("registry cert member_did_aw=%v", gotCert["member_did_aw"])
 	}
-	if registeredCert["member_address"] != "acme.com/alice" {
-		t.Fatalf("registry cert member_address=%v", registeredCert["member_address"])
+	if gotCert["member_address"] != "acme.com/alice" {
+		t.Fatalf("registry cert member_address=%v", gotCert["member_address"])
 	}
-	if registeredCert["identity_scope"] != awid.IdentityModeGlobal {
-		t.Fatalf("registry cert lifetime=%v", registeredCert["identity_scope"])
+	if gotCert["identity_scope"] != awid.IdentityModeGlobal {
+		t.Fatalf("registry cert lifetime=%v", gotCert["identity_scope"])
 	}
 }
 

--- a/cli/go/cmd/aw/id_team_test.go
+++ b/cli/go/cmd/aw/id_team_test.go
@@ -1412,13 +1412,13 @@ func TestTeamInviteDefaultsToActiveTeamAndLocal(t *testing.T) {
 	var registeredCert map[string]any
 	var connectCalls int
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
-				"registry_url":   server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
+				"registry_url":   serverURL,
 			})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/certificates"):
 			if err := json.NewDecoder(r.Body).Decode(&registeredCert); err != nil {
@@ -1449,7 +1449,7 @@ func TestTeamInviteDefaultsToActiveTeamAndLocal(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -1603,7 +1603,7 @@ func TestTeamInviteHostedUsesCloudAuthorityWithoutLocalTeamKey(t *testing.T) {
 	}
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/create-invite":
 			cert := requireCertificateAuthForTest(t, r)
@@ -1620,7 +1620,7 @@ func TestTeamInviteHostedUsesCloudAuthorityWithoutLocalTeamKey(t *testing.T) {
 				"expires_at":     "2026-05-17T00:00:00Z",
 				"namespace_slug": "gracehosted",
 				"namespace":      "gracehosted.aweb.ai",
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/accept-invite":
 			body, _ := io.ReadAll(r.Body)
@@ -1663,7 +1663,7 @@ func TestTeamInviteHostedUsesCloudAuthorityWithoutLocalTeamKey(t *testing.T) {
 				"identity_id":    "agent-bob",
 				"alias":          "bob",
 				"api_key":        "aw_sk_child_not_printed",
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"did":            didKey,
 				"custody":        "self",
 				"lifetime":       "ephemeral",
@@ -1692,16 +1692,16 @@ func TestTeamInviteHostedUsesCloudAuthorityWithoutLocalTeamKey(t *testing.T) {
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
-				"registry_url":   server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
+				"registry_url":   serverURL,
 			})
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
 			writePublishEncryptionKeyResponseForTest(t, w, "agent-bob", "backend:acme.com", "bob")
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	home := t.TempDir()
 	inviterDir := filepath.Join(home, "alice")
@@ -1820,7 +1820,7 @@ func TestTeamAcceptHostedInviteWithAddressCreatesGlobalIdentity(t *testing.T) {
 	var acceptBody map[string]any
 	var acceptVerifiedDID bool
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/accept-invite":
 			body, _ := io.ReadAll(r.Body)
@@ -1897,7 +1897,7 @@ func TestTeamAcceptHostedInviteWithAddressCreatesGlobalIdentity(t *testing.T) {
 				"identity_id":    "agent-durable-child",
 				"name":           "durable-child",
 				"api_key":        "aw_sk_child_not_printed",
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"did":            didKey,
 				"stable_id":      acceptedStableID,
 				"address":        "globalhosted.aweb.ai/durable-child",
@@ -1910,7 +1910,7 @@ func TestTeamAcceptHostedInviteWithAddressCreatesGlobalIdentity(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	home := t.TempDir()
 	acceptDir := filepath.Join(home, "durable")
@@ -2019,7 +2019,7 @@ func TestTeamAcceptHostedGlobalInviteRetryReusesPendingSigningKey(t *testing.T) 
 	var firstStableID string
 	var acceptCalls int
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/v1/did" {
 			t.Fatalf("hosted global retry must not use split DID registration")
 		}
@@ -2067,7 +2067,7 @@ func TestTeamAcceptHostedGlobalInviteRetryReusesPendingSigningKey(t *testing.T) 
 			"identity_id":    "agent-retry-child",
 			"name":           "retry-child",
 			"api_key":        "aw_sk_child_not_printed",
-			"server_url":     server.URL,
+			"server_url":     serverURL,
 			"did":            req.DID,
 			"stable_id":      stableID,
 			"address":        "globalhosted.aweb.ai/retry-child",
@@ -2077,7 +2077,7 @@ func TestTeamAcceptHostedGlobalInviteRetryReusesPendingSigningKey(t *testing.T) 
 			"created":        true,
 			"team_cert":      encoded,
 		})
-	}))
+	})
 	t.Cleanup(server.Close)
 	t.Setenv("AWEB_URL", server.URL)
 	t.Setenv("AWID_REGISTRY_URL", server.URL)
@@ -2116,7 +2116,7 @@ func TestTeamAcceptHostedLocalInviteRetryReusesPendingSigningKey(t *testing.T) {
 	var firstDID string
 	var acceptCalls int
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/spawn/accept-invite" {
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
@@ -2157,7 +2157,7 @@ func TestTeamAcceptHostedLocalInviteRetryReusesPendingSigningKey(t *testing.T) {
 			"identity_id":    "agent-retry-child",
 			"alias":          "retry-child",
 			"api_key":        "aw_sk_child_not_printed",
-			"server_url":     server.URL,
+			"server_url":     serverURL,
 			"did":            req.DID,
 			"custody":        "self",
 			"lifetime":       "ephemeral",
@@ -2165,7 +2165,7 @@ func TestTeamAcceptHostedLocalInviteRetryReusesPendingSigningKey(t *testing.T) {
 			"created":        true,
 			"team_cert":      encoded,
 		})
-	}))
+	})
 	t.Cleanup(server.Close)
 	t.Setenv("AWEB_URL", server.URL)
 	t.Setenv("AWID_REGISTRY_URL", server.URL)
@@ -2480,7 +2480,7 @@ func TestHostedGlobalAcceptNoAddressUsesExistingStableID(t *testing.T) {
 
 	var acceptVerifiedDID bool
 	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newHTTPTestServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/spawn/accept-invite" {
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
@@ -2543,7 +2543,7 @@ func TestHostedGlobalAcceptNoAddressUsesExistingStableID(t *testing.T) {
 			"identity_id":    "agent-alice",
 			"name":           "alice",
 			"api_key":        "aw_sk_child_not_printed",
-			"server_url":     server.URL,
+			"server_url":     serverURL,
 			"did":            globalDID,
 			"stable_id":      globalStableID,
 			"custody":        "self",
@@ -2552,7 +2552,7 @@ func TestHostedGlobalAcceptNoAddressUsesExistingStableID(t *testing.T) {
 			"created":        true,
 			"team_cert":      encoded,
 		})
-	}))
+	})
 	defer server.Close()
 	t.Setenv("AWEB_URL", server.URL)
 

--- a/cli/go/cmd/aw/init_apikey_test.go
+++ b/cli/go/cmd/aw/init_apikey_test.go
@@ -74,7 +74,7 @@ func TestInitAPIKeyAliasCreatesLocalSelfCustodialCLIWorkspace(t *testing.T) {
 	)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/workspaces/init":
 			initAuthHeader = strings.TrimSpace(r.Header.Get("Authorization"))
@@ -104,7 +104,7 @@ func TestInitAPIKeyAliasCreatesLocalSelfCustodialCLIWorkspace(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL + "/api",
+				"server_url":     serverURL + "/api",
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "backend:acme.com",
@@ -135,7 +135,7 @@ func TestInitAPIKeyAliasCreatesLocalSelfCustodialCLIWorkspace(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	result, err := runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -234,7 +234,7 @@ func TestInitAPIKeyGlobalNameCreatesSelfCustodialGlobalCLIIdentity(t *testing.T)
 	var requestOrder []string
 	var registeredDIDKey string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			requestOrder = append(requestOrder, "register_identity")
@@ -284,7 +284,7 @@ func TestInitAPIKeyGlobalNameCreatesSelfCustodialGlobalCLIIdentity(t *testing.T)
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "default:alice.aweb.ai",
@@ -314,7 +314,7 @@ func TestInitAPIKeyGlobalNameCreatesSelfCustodialGlobalCLIIdentity(t *testing.T)
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	result, err := runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -426,7 +426,7 @@ func TestRunAPIKeyBootstrapInitGlobalResumesPartialAfterWorkspaceInitFailure(t *
 	var workspaceInitDIDKeys []string
 	var workspaceInitCalls int
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			var body map[string]any
@@ -488,7 +488,7 @@ func TestRunAPIKeyBootstrapInitGlobalResumesPartialAfterWorkspaceInitFailure(t *
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "default:alice.aweb.ai",
@@ -518,7 +518,7 @@ func TestRunAPIKeyBootstrapInitGlobalResumesPartialAfterWorkspaceInitFailure(t *
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	req := apiKeyInitRequest{
@@ -706,7 +706,7 @@ func TestRunAPIKeyBootstrapInitRejectsResponseDIDMismatch(t *testing.T) {
 	_ = awid.ComputeDIDKey(teamPub)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/workspaces/init":
 			var body map[string]any
@@ -728,7 +728,7 @@ func TestRunAPIKeyBootstrapInitRejectsResponseDIDMismatch(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "backend:acme.com",
@@ -741,7 +741,7 @@ func TestRunAPIKeyBootstrapInitRejectsResponseDIDMismatch(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -764,7 +764,7 @@ func TestRunAPIKeyBootstrapInitRejectsResponseIdentityScopeMismatch(t *testing.T
 	_ = awid.ComputeDIDKey(teamPub)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/workspaces/init":
 			var body map[string]any
@@ -788,7 +788,7 @@ func TestRunAPIKeyBootstrapInitRejectsResponseIdentityScopeMismatch(t *testing.T
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "default:alice.aweb.ai",
@@ -801,7 +801,7 @@ func TestRunAPIKeyBootstrapInitRejectsResponseIdentityScopeMismatch(t *testing.T
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -823,7 +823,7 @@ func TestRunAPIKeyBootstrapInitRejectsTamperedTeamCertificate(t *testing.T) {
 	}
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/workspaces/init":
 			var body map[string]any
@@ -847,7 +847,7 @@ func TestRunAPIKeyBootstrapInitRejectsTamperedTeamCertificate(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "backend:acme.com",
@@ -860,7 +860,7 @@ func TestRunAPIKeyBootstrapInitRejectsTamperedTeamCertificate(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -891,7 +891,7 @@ func TestRunAPIKeyBootstrapInitRejectsMissingOrNonSelfCustody(t *testing.T) {
 			}
 
 			var server *httptest.Server
-			server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/api/v1/workspaces/init":
 					var body map[string]any
@@ -913,7 +913,7 @@ func TestRunAPIKeyBootstrapInitRejectsMissingOrNonSelfCustody(t *testing.T) {
 						t.Fatal(err)
 					}
 					_ = json.NewEncoder(w).Encode(map[string]any{
-						"server_url":     server.URL,
+						"server_url":     serverURL,
 						"team_cert":      encoded,
 						"alias":          "alice",
 						"team_id":        "backend:acme.com",
@@ -926,7 +926,7 @@ func TestRunAPIKeyBootstrapInitRejectsMissingOrNonSelfCustody(t *testing.T) {
 				default:
 					t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 				}
-			}))
+			})
 
 			tmp := t.TempDir()
 			_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -950,7 +950,7 @@ func TestRunAPIKeyBootstrapInitRejectsOverlongWorkspaceAPIKey(t *testing.T) {
 	}
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/workspaces/init":
 			var body map[string]any
@@ -972,7 +972,7 @@ func TestRunAPIKeyBootstrapInitRejectsOverlongWorkspaceAPIKey(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "backend:acme.com",
@@ -986,7 +986,7 @@ func TestRunAPIKeyBootstrapInitRejectsOverlongWorkspaceAPIKey(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -1056,7 +1056,7 @@ func TestRunAPIKeyBootstrapInitDoesNotSendRepoOrigin(t *testing.T) {
 	var connectBody map[string]any
 	var registeredDIDKey string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			var body map[string]any
@@ -1098,7 +1098,7 @@ func TestRunAPIKeyBootstrapInitDoesNotSendRepoOrigin(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "ama",
 				"team_id":        "default:ama.aweb.ai",
@@ -1131,7 +1131,7 @@ func TestRunAPIKeyBootstrapInitDoesNotSendRepoOrigin(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	runGitForTest(t, tmp, "init")
@@ -1168,7 +1168,7 @@ func TestRunAPIKeyBootstrapInitGlobalRollsBackOnConnectFailureAndResumes(t *test
 	var workspaceInitDIDKeys []string
 	var connectCalls int
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			var body map[string]any
@@ -1221,7 +1221,7 @@ func TestRunAPIKeyBootstrapInitGlobalRollsBackOnConnectFailureAndResumes(t *test
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "ama",
 				"team_id":        "default:ama.aweb.ai",
@@ -1256,7 +1256,7 @@ func TestRunAPIKeyBootstrapInitGlobalRollsBackOnConnectFailureAndResumes(t *test
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	preExisting := filepath.Join(tmp, ".aw", "pre-existing.txt")
@@ -1334,7 +1334,7 @@ func TestRunAPIKeyBootstrapInitGlobalRefusesAlreadyRegisteredName(t *testing.T) 
 	existingStableID := awid.ComputeStableID(existingPub)
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			_ = json.NewEncoder(w).Encode(map[string]any{"registered": true})
@@ -1365,7 +1365,7 @@ func TestRunAPIKeyBootstrapInitGlobalRefusesAlreadyRegisteredName(t *testing.T) 
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "ama",
 				"team_id":        "default:ama.aweb.ai",
@@ -1379,7 +1379,7 @@ func TestRunAPIKeyBootstrapInitGlobalRefusesAlreadyRegisteredName(t *testing.T) 
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{

--- a/cli/go/cmd/aw/init_connect_test.go
+++ b/cli/go/cmd/aw/init_connect_test.go
@@ -44,12 +44,12 @@ func TestInitWithCertificateConnectsToServer(t *testing.T) {
 	var gotAuthHeader string
 	var gotCertHeader string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
 			gotAuthHeader = r.Header.Get("Authorization")
@@ -74,7 +74,7 @@ func TestInitWithCertificateConnectsToServer(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -221,12 +221,12 @@ func TestInitWithCertificatePreservesExplicitAPIPath(t *testing.T) {
 
 	var gotConnectPath string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL + "/api",
-				"aweb_url":       server.URL + "/api",
+				"onboarding_url": serverURL + "/api",
+				"aweb_url":       serverURL + "/api",
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/connect":
 			gotConnectPath = r.URL.Path
@@ -247,7 +247,7 @@ func TestInitWithCertificatePreservesExplicitAPIPath(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -334,12 +334,12 @@ func TestConnectResponseWritesWorkspaceYAML(t *testing.T) {
 	}
 
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": server.URL,
-				"aweb_url":       server.URL,
+				"onboarding_url": serverURL,
+				"aweb_url":       serverURL,
 			})
 		default:
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -350,7 +350,7 @@ func TestConnectResponseWritesWorkspaceYAML(t *testing.T) {
 				"repo_id":      "repo-uuid-1",
 			})
 		}
-	}))
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cli/go/cmd/aw/init_inbound_mode_test.go
+++ b/cli/go/cmd/aw/init_inbound_mode_test.go
@@ -305,7 +305,7 @@ func TestRunAPIKeyBootstrapInitForwardsInboundModeContactsOnly(t *testing.T) {
 	var initBody map[string]any
 	var registeredDIDKey string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			var body map[string]any
@@ -347,7 +347,7 @@ func TestRunAPIKeyBootstrapInitForwardsInboundModeContactsOnly(t *testing.T) {
 				t.Fatal(encErr)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "default:alice.aweb.ai",
@@ -377,7 +377,7 @@ func TestRunAPIKeyBootstrapInitForwardsInboundModeContactsOnly(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{
@@ -417,7 +417,7 @@ func TestRunAPIKeyBootstrapInitOmitsInboundModeWhenUnset(t *testing.T) {
 	var initBody map[string]any
 	var registeredDIDKey string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/did":
 			var body map[string]any
@@ -459,7 +459,7 @@ func TestRunAPIKeyBootstrapInitOmitsInboundModeWhenUnset(t *testing.T) {
 				t.Fatal(encErr)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"team_cert":      encoded,
 				"alias":          "alice",
 				"team_id":        "default:alice.aweb.ai",
@@ -489,7 +489,7 @@ func TestRunAPIKeyBootstrapInitOmitsInboundModeWhenUnset(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	tmp := t.TempDir()
 	_, err = runAPIKeyBootstrapInit(apiKeyInitRequest{

--- a/cli/go/cmd/aw/local_surface_e2e_test.go
+++ b/cli/go/cmd/aw/local_surface_e2e_test.go
@@ -406,7 +406,7 @@ func TestHostedTeamAddProfiledAgentMaterializesAndAppliesRuntime(t *testing.T) {
 
 	var createInviteCalls, acceptInviteCalls int
 	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newHTTPTestServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/create-invite":
 			cert := requireCertificateAuthForTest(t, r)
@@ -423,7 +423,7 @@ func TestHostedTeamAddProfiledAgentMaterializesAndAppliesRuntime(t *testing.T) {
 				"expires_at":     "2026-08-17T00:00:00Z",
 				"namespace_slug": "gracehosted",
 				"namespace":      "gracehosted.aweb.ai",
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/accept-invite":
 			acceptInviteCalls++
@@ -458,7 +458,7 @@ func TestHostedTeamAddProfiledAgentMaterializesAndAppliesRuntime(t *testing.T) {
 				"identity_id":    "agent-" + alias,
 				"alias":          alias,
 				"api_key":        "aw_sk_child_not_printed",
-				"server_url":     server.URL,
+				"server_url":     serverURL,
 				"did":            didKey,
 				"custody":        "self",
 				"lifetime":       "ephemeral",
@@ -467,7 +467,7 @@ func TestHostedTeamAddProfiledAgentMaterializesAndAppliesRuntime(t *testing.T) {
 				"team_cert":      encoded,
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{"onboarding_url": server.URL, "aweb_url": server.URL, "registry_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"onboarding_url": serverURL, "aweb_url": serverURL, "registry_url": serverURL})
 		case r.Method == http.MethodGet && (r.URL.Path == "/v1/agents/heartbeat" || r.URL.Path == "/api/v1/agents/heartbeat"):
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
@@ -499,7 +499,7 @@ func TestHostedTeamAddProfiledAgentMaterializesAndAppliesRuntime(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	defer server.Close()
 	t.Setenv("AWEB_URL", server.URL)
 	t.Setenv(libraryURLEnvVar, server.URL)

--- a/cli/go/cmd/aw/onboarding_wizard_test.go
+++ b/cli/go/cmd/aw/onboarding_wizard_test.go
@@ -785,78 +785,80 @@ func TestExecuteHostedPathConnectsAndClaimsHumanAgainstServers(t *testing.T) {
 		}
 	}))
 
-	onboardingServer := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       awebServer.URL,
-				"registry_url":   registryServer.URL,
-				"version":        "1.7.0",
-				"features":       []string{"managed_namespaces", "claim_human"},
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	onboardingServer := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       awebServer.URL,
+					"registry_url":   registryServer.URL,
+					"version":        "1.7.0",
+					"features":       []string{"managed_namespaces", "claim_human"},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				checkBodies = append(checkBodies, body)
+				username := strings.TrimSpace(body["username"].(string))
+				w.Header().Set("Content-Type", "application/json")
+				if username == "Invalid_Probe" {
+					_, _ = w.Write([]byte(`{"available":false,"reason":"invalid_format"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"available":true}`))
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
+					t.Fatal(err)
+				}
+				username := strings.TrimSpace(signupBody["username"].(string))
+				alias := strings.TrimSpace(signupBody["alias"].(string))
+				didKey := strings.TrimSpace(signupBody["did_key"].(string))
+				didAW := strings.TrimSpace(signupBody["did_aw"].(string))
+				memberAddress := username + ".aweb.ai/" + alias
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:          "default:" + username + ".aweb.ai",
+					MemberDIDKey:  didKey,
+					MemberDIDAW:   didAW,
+					MemberAddress: memberAddress,
+					Alias:         alias,
+					Lifetime:      awid.LifetimePersistent,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"user_id":          "user-1",
+					"username":         username,
+					"org_id":           "org-1",
+					"namespace_domain": username + ".aweb.ai",
+					"team_id":          "default:" + username + ".aweb.ai",
+					"api_key":          "aw_sk_guided_hosted",
+					"certificate":      encodedCert,
+					"did_aw":           didAW,
+					"member_address":   memberAddress,
+					"alias":            alias,
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				if err := json.NewDecoder(r.Body).Decode(&claimBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "verification_sent",
+					"email":  claimBody["email"],
+				})
+			default:
+				t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
 			}
-			checkBodies = append(checkBodies, body)
-			username := strings.TrimSpace(body["username"].(string))
-			w.Header().Set("Content-Type", "application/json")
-			if username == "Invalid_Probe" {
-				_, _ = w.Write([]byte(`{"available":false,"reason":"invalid_format"}`))
-				return
-			}
-			_, _ = w.Write([]byte(`{"available":true}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
-				t.Fatal(err)
-			}
-			username := strings.TrimSpace(signupBody["username"].(string))
-			alias := strings.TrimSpace(signupBody["alias"].(string))
-			didKey := strings.TrimSpace(signupBody["did_key"].(string))
-			didAW := strings.TrimSpace(signupBody["did_aw"].(string))
-			memberAddress := username + ".aweb.ai/" + alias
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:          "default:" + username + ".aweb.ai",
-				MemberDIDKey:  didKey,
-				MemberDIDAW:   didAW,
-				MemberAddress: memberAddress,
-				Alias:         alias,
-				Lifetime:      awid.LifetimePersistent,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"user_id":          "user-1",
-				"username":         username,
-				"org_id":           "org-1",
-				"namespace_domain": username + ".aweb.ai",
-				"team_id":          "default:" + username + ".aweb.ai",
-				"api_key":          "aw_sk_guided_hosted",
-				"certificate":      encodedCert,
-				"did_aw":           didAW,
-				"member_address":   memberAddress,
-				"alias":            alias,
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			if err := json.NewDecoder(r.Body).Decode(&claimBody); err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "verification_sent",
-				"email":  claimBody["email"],
-			})
-		default:
-			t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = onboardingServer.URL
+		})
+	})
 
 	tmp := t.TempDir()
 	var out bytes.Buffer
@@ -1034,86 +1036,88 @@ func TestExecuteHostedPathRetriesUsernameAfterSignupConflict(t *testing.T) {
 
 	var signupBodies []map[string]any
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   registryServer.URL,
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   registryServer.URL,
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				username := strings.TrimSpace(body["username"].(string))
+				w.Header().Set("Content-Type", "application/json")
+				if username == "Invalid_Probe" {
+					_, _ = w.Write([]byte(`{"available":false,"reason":"invalid_format"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"available":true}`))
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				signupBodies = append(signupBodies, body)
+				username := strings.TrimSpace(body["username"].(string))
+				if len(signupBodies) == 1 {
+					w.WriteHeader(http.StatusConflict)
+					_, _ = w.Write([]byte(`{"detail":"username taken"}`))
+					return
+				}
+				alias := strings.TrimSpace(body["alias"].(string))
+				didKey := strings.TrimSpace(body["did_key"].(string))
+				didAW := strings.TrimSpace(body["did_aw"].(string))
+				memberAddress := username + ".aweb.ai/" + alias
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:          "default:" + username + ".aweb.ai",
+					MemberDIDKey:  didKey,
+					MemberDIDAW:   didAW,
+					MemberAddress: memberAddress,
+					Alias:         alias,
+					Lifetime:      awid.LifetimePersistent,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"user_id":          "user-1",
+					"username":         username,
+					"org_id":           "org-1",
+					"namespace_domain": username + ".aweb.ai",
+					"team_id":          "default:" + username + ".aweb.ai",
+					"api_key":          "aw_sk_guided_hosted",
+					"certificate":      encodedCert,
+					"did_aw":           didAW,
+					"member_address":   memberAddress,
+					"alias":            alias,
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"team_id":      "default:jack-2.aweb.ai",
+					"alias":        "laptop",
+					"agent_id":     "agent-1",
+					"workspace_id": "ws-1",
+					"repo_id":      "repo-1",
+					"team_did_key": awid.ComputeDIDKey(teamKey.Public().(ed25519.PublicKey)),
+				})
+			case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
+				writePublishEncryptionKeyResponseForTest(t, w, "agent-1", "default:jack-2.aweb.ai", "laptop")
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 			}
-			username := strings.TrimSpace(body["username"].(string))
-			w.Header().Set("Content-Type", "application/json")
-			if username == "Invalid_Probe" {
-				_, _ = w.Write([]byte(`{"available":false,"reason":"invalid_format"}`))
-				return
-			}
-			_, _ = w.Write([]byte(`{"available":true}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
-			}
-			signupBodies = append(signupBodies, body)
-			username := strings.TrimSpace(body["username"].(string))
-			if len(signupBodies) == 1 {
-				w.WriteHeader(http.StatusConflict)
-				_, _ = w.Write([]byte(`{"detail":"username taken"}`))
-				return
-			}
-			alias := strings.TrimSpace(body["alias"].(string))
-			didKey := strings.TrimSpace(body["did_key"].(string))
-			didAW := strings.TrimSpace(body["did_aw"].(string))
-			memberAddress := username + ".aweb.ai/" + alias
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:          "default:" + username + ".aweb.ai",
-				MemberDIDKey:  didKey,
-				MemberDIDAW:   didAW,
-				MemberAddress: memberAddress,
-				Alias:         alias,
-				Lifetime:      awid.LifetimePersistent,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"user_id":          "user-1",
-				"username":         username,
-				"org_id":           "org-1",
-				"namespace_domain": username + ".aweb.ai",
-				"team_id":          "default:" + username + ".aweb.ai",
-				"api_key":          "aw_sk_guided_hosted",
-				"certificate":      encodedCert,
-				"did_aw":           didAW,
-				"member_address":   memberAddress,
-				"alias":            alias,
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"team_id":      "default:jack-2.aweb.ai",
-				"alias":        "laptop",
-				"agent_id":     "agent-1",
-				"workspace_id": "ws-1",
-				"repo_id":      "repo-1",
-				"team_did_key": awid.ComputeDIDKey(teamKey.Public().(ed25519.PublicKey)),
-			})
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
-			writePublishEncryptionKeyResponseForTest(t, w, "agent-1", "default:jack-2.aweb.ai", "laptop")
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	tmp := t.TempDir()
 	var out bytes.Buffer
@@ -1156,28 +1160,30 @@ func TestExecuteHostedPathRetriesUsernameAfterSignupConflict(t *testing.T) {
 func TestExecuteHostedPathDoesNotPromptForUsernameRetryWhenNonInteractive(t *testing.T) {
 	var signupCalls int
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   onboardingURL,
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			signupCalls++
-			w.WriteHeader(http.StatusConflict)
-			_, _ = w.Write([]byte(`{"detail":"username taken"}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
-			t.Fatal("connect must not run after signup conflict")
-		default:
-			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   onboardingURL,
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				signupCalls++
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"detail":"username taken"}`))
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
+				t.Fatal("connect must not run after signup conflict")
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+		})
+	})
 
 	_, err := executeHostedPath(guidedOnboardingRequest{
 		WorkingDir:     t.TempDir(),
@@ -1305,69 +1311,71 @@ func TestExecuteHostedPathWithCompatibilityAliasCreatesSelfCustodialGlobalCLIIde
 		}
 	}))
 
-	onboardingServer := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       awebServer.URL,
-				"registry_url":   registryServer.URL,
-				"version":        "1.7.0",
-				"features":       []string{"managed_namespaces"},
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	onboardingServer := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       awebServer.URL,
+					"registry_url":   registryServer.URL,
+					"version":        "1.7.0",
+					"features":       []string{"managed_namespaces"},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				username := strings.TrimSpace(body["username"].(string))
+				w.Header().Set("Content-Type", "application/json")
+				if username == "Invalid_Probe" {
+					_, _ = w.Write([]byte(`{"available":false,"reason":"invalid_format"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"available":true}`))
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
+					t.Fatal(err)
+				}
+				username := strings.TrimSpace(signupBody["username"].(string))
+				alias := strings.TrimSpace(signupBody["alias"].(string))
+				didKey := strings.TrimSpace(signupBody["did_key"].(string))
+				didAW := strings.TrimSpace(signupBody["did_aw"].(string))
+				memberAddress := username + ".aweb.ai/" + alias
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:          "default:" + username + ".aweb.ai",
+					MemberDIDKey:  didKey,
+					MemberDIDAW:   didAW,
+					MemberAddress: memberAddress,
+					Alias:         alias,
+					Lifetime:      awid.LifetimePersistent,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"user_id":          "user-1",
+					"username":         username,
+					"org_id":           "org-1",
+					"namespace_domain": username + ".aweb.ai",
+					"team_id":          "default:" + username + ".aweb.ai",
+					"api_key":          "aw_sk_guided_hosted",
+					"certificate":      encodedCert,
+					"did_aw":           didAW,
+					"member_address":   memberAddress,
+					"alias":            alias,
+				})
+			default:
+				t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
 			}
-			username := strings.TrimSpace(body["username"].(string))
-			w.Header().Set("Content-Type", "application/json")
-			if username == "Invalid_Probe" {
-				_, _ = w.Write([]byte(`{"available":false,"reason":"invalid_format"}`))
-				return
-			}
-			_, _ = w.Write([]byte(`{"available":true}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
-				t.Fatal(err)
-			}
-			username := strings.TrimSpace(signupBody["username"].(string))
-			alias := strings.TrimSpace(signupBody["alias"].(string))
-			didKey := strings.TrimSpace(signupBody["did_key"].(string))
-			didAW := strings.TrimSpace(signupBody["did_aw"].(string))
-			memberAddress := username + ".aweb.ai/" + alias
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:          "default:" + username + ".aweb.ai",
-				MemberDIDKey:  didKey,
-				MemberDIDAW:   didAW,
-				MemberAddress: memberAddress,
-				Alias:         alias,
-				Lifetime:      awid.LifetimePersistent,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"user_id":          "user-1",
-				"username":         username,
-				"org_id":           "org-1",
-				"namespace_domain": username + ".aweb.ai",
-				"team_id":          "default:" + username + ".aweb.ai",
-				"api_key":          "aw_sk_guided_hosted",
-				"certificate":      encodedCert,
-				"did_aw":           didAW,
-				"member_address":   memberAddress,
-				"alias":            alias,
-			})
-		default:
-			t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = onboardingServer.URL
+		})
+	})
 
 	tmp := t.TempDir()
 	var out bytes.Buffer
@@ -1462,52 +1470,54 @@ func TestExecuteHostedPathDefaultsToLocalWithAliceAlias(t *testing.T) {
 		}
 	}))
 
-	onboardingServer := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       awebServer.URL,
-				"registry_url":   registryServer.URL,
-				"version":        "1.7.0",
-				"features":       []string{"managed_namespaces"},
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"available":true}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
-				t.Fatal(err)
+	onboardingServer := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       awebServer.URL,
+					"registry_url":   registryServer.URL,
+					"version":        "1.7.0",
+					"features":       []string{"managed_namespaces"},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"available":true}`))
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
+					t.Fatal(err)
+				}
+				username := strings.TrimSpace(signupBody["username"].(string))
+				alias := strings.TrimSpace(signupBody["alias"].(string))
+				didKey := strings.TrimSpace(signupBody["did_key"].(string))
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:         "default:" + username + ".aweb.ai",
+					MemberDIDKey: didKey,
+					Alias:        alias,
+					Lifetime:     awid.LifetimeEphemeral,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				certB64, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"certificate":    certB64,
+					"did_aw":         "",
+					"member_address": "",
+					"alias":          alias,
+					"team_id":        "default:" + username + ".aweb.ai",
+					"api_key":        "aw_sk_guided_hosted",
+				})
+			default:
+				t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
 			}
-			username := strings.TrimSpace(signupBody["username"].(string))
-			alias := strings.TrimSpace(signupBody["alias"].(string))
-			didKey := strings.TrimSpace(signupBody["did_key"].(string))
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:         "default:" + username + ".aweb.ai",
-				MemberDIDKey: didKey,
-				Alias:        alias,
-				Lifetime:     awid.LifetimeEphemeral,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			certB64, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"certificate":    certB64,
-				"did_aw":         "",
-				"member_address": "",
-				"alias":          alias,
-				"team_id":        "default:" + username + ".aweb.ai",
-				"api_key":        "aw_sk_guided_hosted",
-			})
-		default:
-			t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = onboardingServer.URL
+		})
+	})
 
 	tmp := t.TempDir()
 	var out bytes.Buffer
@@ -1619,65 +1629,67 @@ func TestExecuteHostedPathGlobalDoesNotSuggestUserAsAlias(t *testing.T) {
 		}
 	}))
 
-	onboardingServer := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       awebServer.URL,
-				"registry_url":   registryServer.URL,
-				"version":        "1.7.0",
-				"features":       []string{"managed_namespaces"},
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	onboardingServer := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       awebServer.URL,
+					"registry_url":   registryServer.URL,
+					"version":        "1.7.0",
+					"features":       []string{"managed_namespaces"},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"available":true}`))
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
+					t.Fatal(err)
+				}
+				username := strings.TrimSpace(signupBody["username"].(string))
+				alias := strings.TrimSpace(signupBody["alias"].(string))
+				didKey := strings.TrimSpace(signupBody["did_key"].(string))
+				didAW := strings.TrimSpace(signupBody["did_aw"].(string))
+				memberAddress := username + ".aweb.ai/" + alias
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:          "default:" + username + ".aweb.ai",
+					MemberDIDKey:  didKey,
+					MemberDIDAW:   didAW,
+					MemberAddress: memberAddress,
+					Alias:         alias,
+					Lifetime:      awid.LifetimePersistent,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				certB64, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Mirror the production cli-signup response shape that
+				// validateHostedSignupResponse expects: certificate (base64), did_aw,
+				// member_address, alias. Older test-fixture variants used
+				// "team_certificate" + missing did_aw and predate the validate path
+				// added in onboarding_wizard.go:665.
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"certificate":    certB64,
+					"did_aw":         didAW,
+					"member_address": memberAddress,
+					"alias":          alias,
+					"team_id":        "default:" + username + ".aweb.ai",
+					"api_key":        "aw_sk_guided_hosted",
+				})
+			default:
+				t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"available":true}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			if err := json.NewDecoder(r.Body).Decode(&signupBody); err != nil {
-				t.Fatal(err)
-			}
-			username := strings.TrimSpace(signupBody["username"].(string))
-			alias := strings.TrimSpace(signupBody["alias"].(string))
-			didKey := strings.TrimSpace(signupBody["did_key"].(string))
-			didAW := strings.TrimSpace(signupBody["did_aw"].(string))
-			memberAddress := username + ".aweb.ai/" + alias
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:          "default:" + username + ".aweb.ai",
-				MemberDIDKey:  didKey,
-				MemberDIDAW:   didAW,
-				MemberAddress: memberAddress,
-				Alias:         alias,
-				Lifetime:      awid.LifetimePersistent,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			certB64, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// Mirror the production cli-signup response shape that
-			// validateHostedSignupResponse expects: certificate (base64), did_aw,
-			// member_address, alias. Older test-fixture variants used
-			// "team_certificate" + missing did_aw and predate the validate path
-			// added in onboarding_wizard.go:665.
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"certificate":    certB64,
-				"did_aw":         didAW,
-				"member_address": memberAddress,
-				"alias":          alias,
-				"team_id":        "default:" + username + ".aweb.ai",
-				"api_key":        "aw_sk_guided_hosted",
-			})
-		default:
-			t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = onboardingServer.URL
+		})
+	})
 
 	tmp := t.TempDir()
 	var out bytes.Buffer
@@ -2380,68 +2392,70 @@ func TestExecuteHostedPathOffersClaimHumanAfterPostInitSetup(t *testing.T) {
 	}
 
 	var onboardingURL string
-	server := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"onboarding_url": onboardingURL,
-				"aweb_url":       onboardingURL,
-				"registry_url":   onboardingURL,
-				"version":        "1.7.0",
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
-			_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	server := newLocalHTTPServerWithURL(t, func(baseURL string) http.Handler {
+		onboardingURL = baseURL
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"onboarding_url": onboardingURL,
+					"aweb_url":       onboardingURL,
+					"registry_url":   onboardingURL,
+					"version":        "1.7.0",
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/check-username":
+				_ = json.NewEncoder(w).Encode(map[string]any{"available": true})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/onboarding/cli-signup":
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				didKey := strings.TrimSpace(body["did_key"].(string))
+				alias := strings.TrimSpace(body["alias"].(string))
+				cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
+					Team:         "default:jack.aweb.ai",
+					MemberDIDKey: didKey,
+					Alias:        alias,
+					Lifetime:     awid.LifetimeEphemeral,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"user_id":          "user-1",
+					"username":         "jack",
+					"org_id":           "org-1",
+					"namespace_domain": "jack.aweb.ai",
+					"team_id":          "default:jack.aweb.ai",
+					"api_key":          "aw_sk_guided_hosted",
+					"certificate":      encodedCert,
+					"did_aw":           "",
+					"member_address":   "",
+					"alias":            alias,
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"team_id":      "default:jack.aweb.ai",
+					"alias":        "laptop",
+					"agent_id":     "agent-1",
+					"workspace_id": "ws-1",
+					"repo_id":      "repo-1",
+					"team_did_key": awid.ComputeDIDKey(teamKey.Public().(ed25519.PublicKey)),
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
+				events = append(events, "claim-human")
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "verification_sent", "email": "jack@example.com"})
+			case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
+				writePublishEncryptionKeyResponseForTest(t, w, "agent-1", "default:jack.aweb.ai", "laptop")
+			default:
+				t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
 			}
-			didKey := strings.TrimSpace(body["did_key"].(string))
-			alias := strings.TrimSpace(body["alias"].(string))
-			cert, err := awid.SignTeamCertificate(teamKey, awid.TeamCertificateFields{
-				Team:         "default:jack.aweb.ai",
-				MemberDIDKey: didKey,
-				Alias:        alias,
-				Lifetime:     awid.LifetimeEphemeral,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			encodedCert, err := awid.EncodeTeamCertificateHeader(cert)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"user_id":          "user-1",
-				"username":         "jack",
-				"org_id":           "org-1",
-				"namespace_domain": "jack.aweb.ai",
-				"team_id":          "default:jack.aweb.ai",
-				"api_key":          "aw_sk_guided_hosted",
-				"certificate":      encodedCert,
-				"did_aw":           "",
-				"member_address":   "",
-				"alias":            alias,
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"team_id":      "default:jack.aweb.ai",
-				"alias":        "laptop",
-				"agent_id":     "agent-1",
-				"workspace_id": "ws-1",
-				"repo_id":      "repo-1",
-				"team_did_key": awid.ComputeDIDKey(teamKey.Public().(ed25519.PublicKey)),
-			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/claim-human":
-			events = append(events, "claim-human")
-			_ = json.NewEncoder(w).Encode(map[string]any{"status": "verification_sent", "email": "jack@example.com"})
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/agents/me/encryption-key":
-			writePublishEncryptionKeyResponseForTest(t, w, "agent-1", "default:jack.aweb.ai", "laptop")
-		default:
-			t.Fatalf("unexpected hosted onboarding request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	onboardingURL = server.URL
+		})
+	})
 
 	var out bytes.Buffer
 	_, err = executeHostedPath(guidedOnboardingRequest{

--- a/cli/go/cmd/aw/team_extend_test.go
+++ b/cli/go/cmd/aw/team_extend_test.go
@@ -255,7 +255,7 @@ func TestTeamExtendAPIKeyTeamIDMismatchRollsBackWithExplicitAuth(t *testing.T) {
 	var initCalls, connectCalls, removeCalls int
 	var removeAuth string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspaces/init":
 			initCalls++
@@ -276,7 +276,7 @@ func TestTeamExtendAPIKeyTeamIDMismatchRollsBackWithExplicitAuth(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": server.URL, "team_cert": encoded, "alias": alias, "team_id": actualTeamID, "workspace_id": "ws-rollback", "did": didKey, "identity_scope": awid.IdentityModeLocal, "custody": awid.CustodySelf, "api_key": returnedKey})
+			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": serverURL, "team_cert": encoded, "alias": alias, "team_id": actualTeamID, "workspace_id": "ws-rollback", "did": didKey, "identity_scope": awid.IdentityModeLocal, "custody": awid.CustodySelf, "api_key": returnedKey})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/connect":
 			connectCalls++
 			requireCertificateAuthForTest(t, r)
@@ -293,7 +293,7 @@ func TestTeamExtendAPIKeyTeamIDMismatchRollsBackWithExplicitAuth(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	teamHumanExtendAPIKey = explicitKey
 	teamHumanExtendTeamID = "default:other.aweb.ai"
 	initAwebURL = server.URL

--- a/cli/go/cmd/aw/team_extend_test.go
+++ b/cli/go/cmd/aw/team_extend_test.go
@@ -63,8 +63,8 @@ func TestTeamAddAmbientAPIKeyKeepsActiveTeamAuthority(t *testing.T) {
 	if err := awconfig.SaveTeamState(root, &awconfig.TeamState{
 		ActiveTeam: "active:acme.com",
 		Memberships: []awconfig.TeamMembership{{
-			TeamID:  "active:acme.com",
-			Alias:   "captain",
+			TeamID:   "active:acme.com",
+			Alias:    "captain",
 			CertPath: ".aw/team-certs/active.pem",
 		}},
 	}); err != nil {

--- a/cli/go/cmd/aw/team_human_create_test.go
+++ b/cli/go/cmd/aw/team_human_create_test.go
@@ -926,7 +926,7 @@ func TestTeamHumanCreateAPIKeyToleratesAPISuffixedAwebURL(t *testing.T) {
 
 			var initPaths []string
 			var server *httptest.Server
-			server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/api/v1/workspaces/init":
 					initPaths = append(initPaths, r.URL.Path)
@@ -949,7 +949,7 @@ func TestTeamHumanCreateAPIKeyToleratesAPISuffixedAwebURL(t *testing.T) {
 						t.Fatal(err)
 					}
 					_ = json.NewEncoder(w).Encode(map[string]any{
-						"server_url":     server.URL,
+						"server_url":     serverURL,
 						"team_cert":      encoded,
 						"alias":          "eng",
 						"team_id":        "backend:acme.com",
@@ -977,7 +977,7 @@ func TestTeamHumanCreateAPIKeyToleratesAPISuffixedAwebURL(t *testing.T) {
 				default:
 					t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 				}
-			}))
+			})
 
 			t.Setenv("AWEB_API_KEY", apiKey)
 			t.Setenv("AWEB_URL", server.URL+tc.suffix)
@@ -1005,7 +1005,7 @@ func TestTeamHumanCreateRootOperatorDefaultsToTeamName(t *testing.T) {
 	teamDIDKey := awid.ComputeDIDKey(teamPub)
 	var gotInitAlias string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/workspaces/init":
 			var body map[string]any
@@ -1022,7 +1022,7 @@ func TestTeamHumanCreateRootOperatorDefaultsToTeamName(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": server.URL, "team_cert": encoded, "alias": gotInitAlias, "team_id": "backend:acme.com", "workspace_id": "ws-1", "did": didKey, "identity_scope": awid.IdentityModeLocal, "custody": awid.CustodySelf, "api_key": "workspace-sk-ephemeral"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": serverURL, "team_cert": encoded, "alias": gotInitAlias, "team_id": "backend:acme.com", "workspace_id": "ws-1", "did": didKey, "identity_scope": awid.IdentityModeLocal, "custody": awid.CustodySelf, "api_key": "workspace-sk-ephemeral"})
 		case "/api/v1/connect", "/v1/connect":
 			requireCertificateAuthForTest(t, r)
 			_ = json.NewEncoder(w).Encode(map[string]any{"team_id": "backend:acme.com", "alias": gotInitAlias, "agent_id": "agent-1", "workspace_id": "ws-1", "repo_id": "", "team_did_key": teamDIDKey})
@@ -1033,7 +1033,7 @@ func TestTeamHumanCreateRootOperatorDefaultsToTeamName(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 
 	t.Setenv("AWEB_API_KEY", apiKey)
 	t.Setenv("AWEB_URL", server.URL)
@@ -1209,7 +1209,7 @@ func TestTeamHumanAddAPIKeyNoActiveTeamBootstrapsAndMaterializesProfile(t *testi
 	var initCalls, connectCalls int
 	var initBody map[string]any
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspaces/init":
 			initCalls++
@@ -1228,7 +1228,7 @@ func TestTeamHumanAddAPIKeyNoActiveTeamBootstrapsAndMaterializesProfile(t *testi
 			if err != nil {
 				t.Fatal(err)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": server.URL, "team_cert": encoded, "alias": "developer", "team_id": "default:launch.aweb.ai", "workspace_id": "ws-dev", "did": didKey, "stable_id": "", "identity_scope": awid.IdentityModeLocal, "custody": awid.CustodySelf, "api_key": "workspace-sk-dev"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": serverURL, "team_cert": encoded, "alias": "developer", "team_id": "default:launch.aweb.ai", "workspace_id": "ws-dev", "did": didKey, "stable_id": "", "identity_scope": awid.IdentityModeLocal, "custody": awid.CustodySelf, "api_key": "workspace-sk-dev"})
 		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/connect" || r.URL.Path == "/v1/connect"):
 			connectCalls++
 			requireCertificateAuthForTest(t, r)
@@ -1248,7 +1248,7 @@ func TestTeamHumanAddAPIKeyNoActiveTeamBootstrapsAndMaterializesProfile(t *testi
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	t.Setenv("AWEB_URL", server.URL+"/api")
 	t.Setenv(libraryURLEnvVar, server.URL)
 
@@ -1296,7 +1296,7 @@ func TestTeamHumanAddAPIKeyNoActiveTeamBootstrapsGlobalThroughWorkspaceInit(t *t
 	var initBody map[string]any
 	var registeredDIDKey string
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/did":
 			requestOrder = append(requestOrder, "register_identity")
@@ -1330,7 +1330,7 @@ func TestTeamHumanAddAPIKeyNoActiveTeamBootstrapsGlobalThroughWorkspaceInit(t *t
 			if err != nil {
 				t.Fatal(err)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": server.URL, "team_cert": encoded, "alias": "global-dev", "team_id": "default:launch.aweb.ai", "workspace_id": "ws-global", "did": didKey, "stable_id": stableID, "identity_scope": awid.IdentityModeGlobal, "custody": awid.CustodySelf, "api_key": "workspace-sk-global"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"server_url": serverURL, "team_cert": encoded, "alias": "global-dev", "team_id": "default:launch.aweb.ai", "workspace_id": "ws-global", "did": didKey, "stable_id": stableID, "identity_scope": awid.IdentityModeGlobal, "custody": awid.CustodySelf, "api_key": "workspace-sk-global"})
 		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/connect" || r.URL.Path == "/v1/connect"):
 			requireCertificateAuthForTest(t, r)
 			_ = json.NewEncoder(w).Encode(map[string]any{"team_id": "default:launch.aweb.ai", "alias": "global-dev", "agent_id": "global-dev", "workspace_id": "ws-global", "repo_id": "repo-1", "team_did_key": teamDIDKey})
@@ -1349,7 +1349,7 @@ func TestTeamHumanAddAPIKeyNoActiveTeamBootstrapsGlobalThroughWorkspaceInit(t *t
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	t.Setenv("AWEB_URL", server.URL)
 	t.Setenv(libraryURLEnvVar, server.URL)
 	t.Setenv("AWID_REGISTRY_URL", server.URL)
@@ -1621,10 +1621,10 @@ func TestTeamHumanCreateBYOTWithAgentsCreatesTeamAndRoster(t *testing.T) {
 	var namespaceCreated bool
 	var certAliases []string
 	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newHTTPTestServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": server.URL, "registry_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": serverURL, "registry_url": serverURL})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/namespaces/acme.com":
 			if !namespaceCreated {
 				http.NotFound(w, r)
@@ -1665,7 +1665,7 @@ func TestTeamHumanCreateBYOTWithAgentsCreatesTeamAndRoster(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	defer server.Close()
 	t.Setenv("AWEB_URL", server.URL)
 	teamHumanCreateBYOT = true
@@ -1960,10 +1960,10 @@ func TestTeamHumanAddProfileMaterializeFailureRollsBackCreatedHome(t *testing.T)
 	var registeredCertID string
 	var revokedCertID string
 	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newHTTPTestServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": server.URL, "registry_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": serverURL, "registry_url": serverURL})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/namespaces/local/teams/eng":
 			_ = json.NewEncoder(w).Encode(map[string]any{"team_id": "eng:local", "domain": "local", "name": "eng", "team_did_key": teamDID})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/namespaces/local/teams/eng/certificates":
@@ -1992,7 +1992,7 @@ func TestTeamHumanAddProfileMaterializeFailureRollsBackCreatedHome(t *testing.T)
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	defer server.Close()
 	t.Setenv(libraryURLEnvVar, server.URL)
 	writeLocalTeamSignedRequestWorkspaceForTest(t, root, server.URL, "eng:local", "eng", memberDID, memberPriv)
@@ -2038,16 +2038,16 @@ func TestTeamHumanAddHostedProfileMaterializeFailureRequiresTeamKeyForHostedRoll
 	removeAuth := ""
 	removeCalls := 0
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": server.URL, "registry_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": serverURL, "registry_url": serverURL})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/create-invite":
 			cert := requireCertificateAuthForTest(t, r)
 			if cert.Team != teamID {
 				t.Fatalf("create-invite cert team=%q want %q", cert.Team, teamID)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"invite_id": "invite-1", "token": "aw_inv_hosted_rollback_token", "server_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"invite_id": "invite-1", "token": "aw_inv_hosted_rollback_token", "server_url": serverURL})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/accept-invite":
 			var req map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -2065,7 +2065,7 @@ func TestTeamHumanAddHostedProfileMaterializeFailureRequiresTeamKeyForHostedRoll
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"team_id": "server-team-id", "team_slug": "default", "namespace": "rollback.aweb.ai",
-				"identity_id": "agent-developer", "alias": "developer", "server_url": server.URL,
+				"identity_id": "agent-developer", "alias": "developer", "server_url": serverURL,
 				"did": didKey, "custody": "self", "lifetime": "ephemeral", "access_mode": "open", "created": true,
 				"team_cert": encoded,
 			})
@@ -2090,7 +2090,7 @@ func TestTeamHumanAddHostedProfileMaterializeFailureRequiresTeamKeyForHostedRoll
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	defer server.Close()
 	t.Setenv("AWEB_URL", server.URL)
 	t.Setenv(libraryURLEnvVar, server.URL)
@@ -2140,12 +2140,12 @@ func TestTeamHumanAddHostedProfileRollbackFailureIsLoud(t *testing.T) {
 	}
 	justCreatedCertID := ""
 	var server *httptest.Server
-	server = newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server = newLocalHTTPServerHandlerWithURL(t, func(serverURL string, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/discovery":
-			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": server.URL, "registry_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"aweb_url": serverURL, "registry_url": serverURL})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/create-invite":
-			_ = json.NewEncoder(w).Encode(map[string]any{"invite_id": "invite-1", "token": "aw_inv_hosted_rollback_fail_token", "server_url": server.URL})
+			_ = json.NewEncoder(w).Encode(map[string]any{"invite_id": "invite-1", "token": "aw_inv_hosted_rollback_fail_token", "server_url": serverURL})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/spawn/accept-invite":
 			var req map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -2163,7 +2163,7 @@ func TestTeamHumanAddHostedProfileRollbackFailureIsLoud(t *testing.T) {
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"team_id": "server-team-id", "team_slug": "default", "namespace": "rollback-fail.aweb.ai",
-				"identity_id": "agent-developer", "alias": "developer", "server_url": server.URL,
+				"identity_id": "agent-developer", "alias": "developer", "server_url": serverURL,
 				"did": didKey, "custody": "self", "lifetime": "ephemeral", "access_mode": "open", "created": true,
 				"team_cert": encoded,
 			})
@@ -2178,7 +2178,7 @@ func TestTeamHumanAddHostedProfileRollbackFailureIsLoud(t *testing.T) {
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-	}))
+	})
 	defer server.Close()
 	t.Setenv("AWEB_URL", server.URL)
 	t.Setenv(libraryURLEnvVar, server.URL)

--- a/cli/go/cmd/aweb-a2a-gw/main_test.go
+++ b/cli/go/cmd/aweb-a2a-gw/main_test.go
@@ -56,6 +56,8 @@ func TestA2AGatewayBuildsFromWorkspaceConfigServesCardAndSendsTask(t *testing.T)
 				"did_aw":          recipientStableID,
 				"current_did_key": recipientDID,
 			})
+		case "/v1/messages/conversations/conv-1":
+			_ = json.NewEncoder(w).Encode(awid.InboxResponse{Messages: []awid.InboxMessage{}})
 		default:
 			t.Fatalf("unexpected aweb request %s %s", r.Method, r.URL.Path)
 		}

--- a/cli/go/cmd/aweb-a2a-gw/main_test.go
+++ b/cli/go/cmd/aweb-a2a-gw/main_test.go
@@ -518,13 +518,17 @@ func TestA2AGatewayManagedACRefreshFailureKeepsLastGoodRoutes(t *testing.T) {
 func TestA2AGatewayManagedACRefreshExtendsAcceptWindowForStableRevision(t *testing.T) {
 	var posted map[string]any
 	acServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/a2a/gateway/bridge/a2a-gateway/messages" {
+		switch r.URL.Path {
+		case "/api/v1/a2a/gateway/bridge/a2a-gateway/messages":
+			if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+				t.Fatal(err)
+			}
+			_ = json.NewEncoder(w).Encode(awid.SendMessageResponse{MessageID: "msg-1", ConversationID: "conv-1", Status: "sent"})
+		case "/api/v1/a2a/gateway/bridge/a2a-gateway/conversations/conv-1":
+			_ = json.NewEncoder(w).Encode(awid.InboxResponse{Messages: []awid.InboxMessage{}})
+		default:
 			t.Fatalf("unexpected AC request %s %s", r.Method, r.URL.Path)
 		}
-		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
-			t.Fatal(err)
-		}
-		_ = json.NewEncoder(w).Encode(awid.SendMessageResponse{MessageID: "msg-1", ConversationID: "conv-1", Status: "sent"})
 	}))
 	defer acServer.Close()
 

--- a/cli/go/run/loop_test.go
+++ b/cli/go/run/loop_test.go
@@ -2418,85 +2418,77 @@ func TestRealCommandRunnerPTYProvidesTTYAndAcceptsInput(t *testing.T) {
 	}
 
 	const prompt = "Allow? [y/N]"
-	partialSeen := make(chan string, 1)
-	promptReady := make(chan struct{})
-	lineSeen := make(chan string, 1)
+	outputSeen := make(chan string, 16)
 	done := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	go func() {
+		var providerStdin io.WriteCloser
 		var streamedPrompt strings.Builder
 		promptSignaled := false
 		done <- RealCommandRunner(ctx, "", []string{
 			"sh", "-c", "test -t 0 || exit 42; printf 'Allow? [y/N]'; read answer; printf '\\n%s\\n' \"$answer\"",
 		}, func(line string) {
-			select {
-			case lineSeen <- line:
-			default:
-			}
+			outputSeen <- line + "\n"
 		}, &commandOutputSinks{
 			usePTY: true,
 			ptyPartial: func(chunk string) {
+				outputSeen <- chunk
 				if !promptSignaled {
-					partialSeen <- chunk
 					streamedPrompt.WriteString(chunk)
 					if strings.Contains(streamedPrompt.String(), prompt) {
-						close(promptReady)
 						promptSignaled = true
+						_, _ = io.WriteString(providerStdin, "y\n")
 					}
 				}
 			},
 			stdinReady: func(w io.WriteCloser) {
-				go func() {
-					select {
-					case <-promptReady:
-						_, _ = io.WriteString(w, "y\n")
-					case <-ctx.Done():
-					}
-				}()
+				providerStdin = w
 			},
 		})
 	}()
 
-	var gotPrompt strings.Builder
+	var output strings.Builder
 	deadline := time.After(1 * time.Second)
-	for !strings.Contains(gotPrompt.String(), prompt) {
+	for !strings.Contains(output.String(), prompt) {
 		select {
-		case chunk := <-partialSeen:
-			gotPrompt.WriteString(chunk)
+		case chunk := <-outputSeen:
+			output.WriteString(chunk)
 		case <-deadline:
-			t.Fatalf("timed out waiting for PTY partial prompt; got %q", gotPrompt.String())
+			t.Fatalf("timed out waiting for PTY partial prompt; got %q", output.String())
 		}
 	}
-	if gotPrompt.String() != prompt {
-		t.Fatalf("unexpected PTY partial %q", gotPrompt.String())
+	if output.String() != prompt {
+		t.Fatalf("unexpected PTY partial %q", output.String())
 	}
 
 	deadline = time.After(2 * time.Second)
-	for {
+	finished := false
+	for !finished {
 		select {
-		case got := <-lineSeen:
-			if got == "" {
-				continue
+		case chunk := <-outputSeen:
+			output.WriteString(chunk)
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("RealCommandRunner returned error: %v", err)
 			}
-			if got != "y" {
-				t.Fatalf("unexpected PTY stdout line %q", got)
-			}
-			goto ptyDone
+			finished = true
 		case <-deadline:
-			t.Fatal("timed out waiting for PTY input round-trip")
+			t.Fatalf("timed out waiting for PTY runner to finish; output %q", output.String())
 		}
 	}
 
-ptyDone:
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("RealCommandRunner returned error: %v", err)
+drainOutput:
+	for {
+		select {
+		case chunk := <-outputSeen:
+			output.WriteString(chunk)
+		default:
+			break drainOutput
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for PTY runner to finish")
+	}
+	if got := strings.ReplaceAll(output.String(), "\r", ""); !strings.Contains(got, "\ny\n") {
+		t.Fatalf("PTY input was not echoed by the provider: %q", got)
 	}
 }

--- a/cli/go/run/loop_test.go
+++ b/cli/go/run/loop_test.go
@@ -2417,12 +2417,18 @@ func TestRealCommandRunnerPTYProvidesTTYAndAcceptsInput(t *testing.T) {
 		t.Skip("sh not available")
 	}
 
+	const prompt = "Allow? [y/N]"
 	partialSeen := make(chan string, 1)
+	promptReady := make(chan struct{})
 	lineSeen := make(chan string, 1)
 	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	go func() {
-		done <- RealCommandRunner(context.Background(), "", []string{
+		var streamedPrompt strings.Builder
+		promptSignaled := false
+		done <- RealCommandRunner(ctx, "", []string{
 			"sh", "-c", "test -t 0 || exit 42; printf 'Allow? [y/N]'; read answer; printf '\\n%s\\n' \"$answer\"",
 		}, func(line string) {
 			select {
@@ -2432,30 +2438,42 @@ func TestRealCommandRunnerPTYProvidesTTYAndAcceptsInput(t *testing.T) {
 		}, &commandOutputSinks{
 			usePTY: true,
 			ptyPartial: func(chunk string) {
-				select {
-				case partialSeen <- chunk:
-				default:
+				if !promptSignaled {
+					partialSeen <- chunk
+					streamedPrompt.WriteString(chunk)
+					if strings.Contains(streamedPrompt.String(), prompt) {
+						close(promptReady)
+						promptSignaled = true
+					}
 				}
 			},
 			stdinReady: func(w io.WriteCloser) {
 				go func() {
-					time.Sleep(100 * time.Millisecond)
-					_, _ = io.WriteString(w, "y\n")
+					select {
+					case <-promptReady:
+						_, _ = io.WriteString(w, "y\n")
+					case <-ctx.Done():
+					}
 				}()
 			},
 		})
 	}()
 
-	select {
-	case got := <-partialSeen:
-		if got != "Allow? [y/N]" {
-			t.Fatalf("unexpected PTY partial %q", got)
+	var gotPrompt strings.Builder
+	deadline := time.After(1 * time.Second)
+	for !strings.Contains(gotPrompt.String(), prompt) {
+		select {
+		case chunk := <-partialSeen:
+			gotPrompt.WriteString(chunk)
+		case <-deadline:
+			t.Fatalf("timed out waiting for PTY partial prompt; got %q", gotPrompt.String())
 		}
-	case <-time.After(1 * time.Second):
-		t.Fatal("timed out waiting for PTY partial prompt")
+	}
+	if gotPrompt.String() != prompt {
+		t.Fatalf("unexpected PTY partial %q", gotPrompt.String())
 	}
 
-	deadline := time.After(2 * time.Second)
+	deadline = time.After(2 * time.Second)
 	for {
 		select {
 		case got := <-lineSeen:


### PR DESCRIPTION
## Summary
- finish the unreviewed aalx partial and widen go-race to `./...`
- replace all 36 AST-enumerated constructor-assigned server URL captures with immutable pre-start URLs
- guard the distinct team-auth key/observation handoffs
- preserve test parallelism; no sleeps, retries, or serialization

## Local development checks
- `go test -race ./... -count=1` (cli/go): PASS, 14 packages; cmd/aw 213.189s
- converted-test targeted race runs: PASS

Acceptance remains the GitHub Actions `go-race` job; local race-clean output is not treated as sufficient evidence.