### PR TITLE
fix(go): patch shipped toolchain and gate reachable vulnerabilities (aall)

### DIFF
--- a/.github/go-vulnerability-exceptions.json
+++ b/.github/go-vulnerability-exceptions.json
@@ -1,17 +1,75 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "accepted_risks": [
     {
       "id": "GO-2026-5320",
       "owner": "aw-coordinator",
       "rationale": "The reported class is XSS in goldmark HTML generation. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter.",
-      "review_on": "2027-01-25"
+      "review_on": "2027-01-25",
+      "affected_module": "github.com/yuin/goldmark",
+      "allowed_project_traces": [
+        [
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "renderCodexAssistantTextWithOptions"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "renderAssistantText"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "handleOutputLine"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "runOnce$7$1"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "scanCommandPipe"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "RealCommandRunner"
+          }
+        ]
+      ]
     },
     {
       "id": "GO-2025-3595",
       "owner": "aw-coordinator",
       "rationale": "The reported class is unsafe web-page generation in x/net/html. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter.",
-      "review_on": "2027-01-25"
+      "review_on": "2027-01-25",
+      "affected_module": "golang.org/x/net",
+      "allowed_project_traces": [
+        [
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "renderCodexAssistantTextWithOptions"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "renderAssistantText"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "handleOutputLine"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "runOnce$7$1"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "scanCommandPipe"
+          },
+          {
+            "package": "github.com/awebai/aw/run",
+            "function": "RealCommandRunner"
+          }
+        ]
+      ]
     }
   ],
   "temporary_deferrals": [
@@ -19,67 +77,78 @@
       "id": "GO-2026-5856",
       "owner": "aw-coordinator",
       "rationale": "Reachable crypto/tls ECH privacy issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.12 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-5039",
       "owner": "aw-coordinator",
       "rationale": "Reachable net/textproto error-escaping issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.11 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-5037",
       "owner": "aw-coordinator",
       "rationale": "Reachable crypto/x509 hostname-parsing resource issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.11 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4971",
       "owner": "aw-coordinator",
       "rationale": "Reachable Windows net package panic; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.10 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4947",
       "owner": "aw-coordinator",
       "rationale": "Reachable crypto/x509 chain-building resource issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4946",
       "owner": "aw-coordinator",
       "rationale": "Reachable crypto/x509 policy-validation resource issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4918",
       "owner": "aw-coordinator",
       "rationale": "Reachable on the live registry/trust path through awid.Client.DoRawWithHeaders and net/http: a malicious HTTP/2 peer can trigger an infinite loop. Go 1.24.13 has no standard-library fix; remediation requires the separately reviewed Go 1.25.10 upgrade. This is the highest-priority deferral.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4870",
       "owner": "aw-coordinator",
       "rationale": "Reachable crypto/tls connection-retention DoS; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4869",
       "owner": "aw-coordinator",
       "rationale": "Reachable archive/tar sparse-file allocation issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4602",
       "owner": "aw-coordinator",
       "rationale": "Reachable os.Root FileInfo escape issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.8 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     },
     {
       "id": "GO-2026-4601",
       "owner": "aw-coordinator",
       "rationale": "Reachable net/url IPv6 host parsing issue on registry, gateway, and CLI HTTP paths; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.8 upgrade.",
-      "expires_on": "2026-08-15"
+      "expires_on": "2026-08-15",
+      "affected_module": "stdlib"
     }
   ]
 }

--- a/.github/go-vulnerability-exceptions.json
+++ b/.github/go-vulnerability-exceptions.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "accepted_risks": [
+    {
+      "id": "GO-2026-5320",
+      "owner": "aw-coordinator",
+      "rationale": "The reported class is XSS in goldmark HTML generation. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter.",
+      "review_on": "2027-01-25"
+    },
+    {
+      "id": "GO-2025-3595",
+      "owner": "aw-coordinator",
+      "rationale": "The reported class is unsafe web-page generation in x/net/html. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter.",
+      "review_on": "2027-01-25"
+    }
+  ],
+  "temporary_deferrals": [
+    {
+      "id": "GO-2026-5856",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable crypto/tls ECH privacy issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.12 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-5039",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable net/textproto error-escaping issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.11 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-5037",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable crypto/x509 hostname-parsing resource issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.11 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4971",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable Windows net package panic; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.10 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4947",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable crypto/x509 chain-building resource issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4946",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable crypto/x509 policy-validation resource issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4918",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable on the live registry/trust path through awid.Client.DoRawWithHeaders and net/http: a malicious HTTP/2 peer can trigger an infinite loop. Go 1.24.13 has no standard-library fix; remediation requires the separately reviewed Go 1.25.10 upgrade. This is the highest-priority deferral.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4870",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable crypto/tls connection-retention DoS; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4869",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable archive/tar sparse-file allocation issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.9 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4602",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable os.Root FileInfo escape issue; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.8 upgrade.",
+      "expires_on": "2026-08-15"
+    },
+    {
+      "id": "GO-2026-4601",
+      "owner": "aw-coordinator",
+      "rationale": "Reachable net/url IPv6 host parsing issue on registry, gateway, and CLI HTTP paths; Go 1.24.13 has no fix and the standard-library fix requires the separately reviewed Go 1.25.8 upgrade.",
+      "expires_on": "2026-08-15"
+    }
+  ]
+}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -6,8 +6,9 @@ name: Dependency Audit
 # drift check against sources in the repository — it can turn red without any
 # change to this repo, which is the point.
 #
-# Scope: Node only. The Go toolchain advisories are default-aall; the Python
-# server/awid lock findings are routed to the teams owning those deploys.
+# Scope: shipped Node dependencies plus reachable Go findings under the exact
+# toolchain pinned by go.mod and the production gateway image. Python server/awid
+# lock findings are routed to the teams owning those deploys.
 
 on:
   push:
@@ -54,3 +55,31 @@ jobs:
 
       - name: Audit Node production dependencies
         run: bash scripts/check-node-audit.sh
+
+  go-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: cli/go/go.mod
+          cache-dependency-path: cli/go/go.sum
+
+      # Prove new reachable IDs, stale/expired exceptions, non-symbol scans,
+      # and source/container/scanner toolchain drift all turn the gate red.
+      - name: Prove the Go audit gate can fail
+        run: python3 scripts/test_check_go_vulnerability_audit.py
+
+      - name: Audit reachable Go vulnerabilities under the shipped toolchain
+        env:
+          AW_GO_VULN_OUTPUT: ${{ runner.temp }}/govulncheck.json
+        run: bash scripts/check-go-vulnerability-audit.sh
+
+      - name: Archive govulncheck output
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: govulncheck-${{ github.sha }}
+          path: ${{ runner.temp }}/govulncheck.json
+          if-no-files-found: warn

--- a/cli/go/Dockerfile.a2a-gw
+++ b/cli/go/Dockerfile.a2a-gw
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_IMAGE=golang:1.24.2-bookworm
+ARG GO_IMAGE=golang:1.24.13-bookworm
 ARG RUNTIME_IMAGE=alpine:3.22
 
 FROM ${GO_IMAGE} AS builder

--- a/cli/go/go.mod
+++ b/cli/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/awebai/aw
 
-go 1.24.2
+go 1.24.13
 
 require github.com/joho/godotenv v1.5.1
 

--- a/scripts/check-go-vulnerability-audit.sh
+++ b/scripts/check-go-vulnerability-audit.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO_MOD="$ROOT/cli/go/go.mod"
+DOCKERFILE="$ROOT/cli/go/Dockerfile.a2a-gw"
+EXCEPTIONS="$ROOT/.github/go-vulnerability-exceptions.json"
+CHECKER="$ROOT/scripts/check_go_vulnerability_audit.py"
+SCANNER_VERSION="v1.1.4"
+
+# Never let Go silently select a newer host toolchain. The audit must describe
+# the toolchain that the source and production container actually ship.
+export GOTOOLCHAIN=local
+expected_go="go$(awk '$1 == "go" { print $2; exit }' "$GO_MOD")"
+actual_go="$(go env GOVERSION)"
+if [[ "$actual_go" != "$expected_go" ]]; then
+  echo "Go vulnerability audit requires $expected_go, but the runner is $actual_go" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+scanner="$tmp/govulncheck"
+GOBIN="$tmp" go install "golang.org/x/vuln/cmd/govulncheck@$SCANNER_VERSION"
+scanner_go="$(go version -m "$scanner" | awk 'NR == 1 { print $NF }')"
+
+findings="${AW_GO_VULN_OUTPUT:-$tmp/govulncheck.json}"
+mkdir -p "$(dirname "$findings")"
+(
+  cd "$ROOT/cli/go"
+  "$scanner" -json ./... >"$findings"
+)
+
+python3 "$CHECKER" \
+  --findings "$findings" \
+  --exceptions "$EXCEPTIONS" \
+  --go-mod "$GO_MOD" \
+  --dockerfile "$DOCKERFILE" \
+  --actual-go "$actual_go" \
+  --scanner-go "$scanner_go" \
+  --scanner-version "$SCANNER_VERSION"

--- a/scripts/check_go_vulnerability_audit.py
+++ b/scripts/check_go_vulnerability_audit.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Validate reachable govulncheck findings against reviewed exceptions."""
+
+import argparse
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+class AuditError(ValueError):
+    pass
+
+
+def read_json_stream(path):
+    text = Path(path).read_text(encoding="utf-8")
+    decoder = json.JSONDecoder()
+    documents = []
+    offset = 0
+    while offset < len(text):
+        while offset < len(text) and text[offset].isspace():
+            offset += 1
+        if offset == len(text):
+            break
+        document, offset = decoder.raw_decode(text, offset)
+        documents.append(document)
+    return documents
+
+
+def reachable_ids(documents):
+    project_module = None
+    for document in documents:
+        sbom = document.get("SBOM")
+        if sbom and sbom.get("modules"):
+            project_module = sbom["modules"][0].get("path")
+            break
+    if not project_module:
+        raise AuditError("govulncheck output has no project module in its SBOM")
+
+    reachable = set()
+    for document in documents:
+        finding = document.get("finding")
+        if not finding:
+            continue
+        trace = finding.get("trace") or []
+        if not trace or not trace[0].get("function"):
+            continue
+        if any(frame.get("module") == project_module for frame in trace):
+            finding_id = finding.get("osv")
+            if finding_id:
+                reachable.add(finding_id)
+    return reachable
+
+
+def _required_text(entry, field, category):
+    value = entry.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise AuditError(f"{category} entry requires non-empty {field}")
+    return value.strip()
+
+
+def _required_date(entry, field, category):
+    value = _required_text(entry, field, category)
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise AuditError(f"{category} entry has invalid {field}: {value}") from exc
+
+
+def validate_baseline(reachable, baseline, today):
+    if baseline.get("schema_version") != 1:
+        raise AuditError("exception baseline schema_version must be 1")
+
+    categories = (
+        ("accepted_risks", "accepted risk", "review_on"),
+        ("temporary_deferrals", "temporary deferral", "expires_on"),
+    )
+    entries_by_id = {}
+    for key, label, date_field in categories:
+        entries = baseline.get(key)
+        if not isinstance(entries, list):
+            raise AuditError(f"exception baseline requires an array named {key}")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise AuditError(f"{label} entries must be objects")
+            finding_id = _required_text(entry, "id", label)
+            _required_text(entry, "owner", label)
+            _required_text(entry, "rationale", label)
+            deadline = _required_date(entry, date_field, label)
+            if finding_id in entries_by_id:
+                raise AuditError(f"duplicate exception for {finding_id}")
+            entries_by_id[finding_id] = (label, deadline)
+
+    approved = set(entries_by_id)
+    unapproved = sorted(reachable - approved)
+    if unapproved:
+        raise AuditError(
+            "unapproved reachable Go vulnerabilities: " + ", ".join(unapproved)
+        )
+    stale = sorted(approved - reachable)
+    if stale:
+        raise AuditError(
+            "baseline entries are no longer reachable and must be removed: "
+            + ", ".join(stale)
+        )
+
+    for finding_id, (label, deadline) in entries_by_id.items():
+        if today < deadline:
+            continue
+        if label == "temporary deferral":
+            raise AuditError(
+                f"temporary deferral for {finding_id} expired on {deadline.isoformat()}"
+            )
+        raise AuditError(
+            f"accepted risk review is due for {finding_id} on {deadline.isoformat()}"
+        )
+
+
+def validate_scan_metadata(documents, expected_go, expected_scanner):
+    configs = [document["config"] for document in documents if "config" in document]
+    if len(configs) != 1:
+        raise AuditError("govulncheck output must contain exactly one config document")
+    config = configs[0]
+    if config.get("scanner_name") != "govulncheck":
+        raise AuditError("scan was not produced by govulncheck")
+    if config.get("scanner_version") != expected_scanner:
+        raise AuditError(
+            "govulncheck version mismatch: "
+            f"got {config.get('scanner_version')}, expected {expected_scanner}"
+        )
+    if config.get("go_version") != expected_go:
+        raise AuditError(
+            "scan Go version mismatch: "
+            f"got {config.get('go_version')}, expected {expected_go}"
+        )
+    if config.get("scan_level") != "symbol" or config.get("scan_mode") != "source":
+        raise AuditError("govulncheck must run as a symbol-level source scan")
+
+
+def validate_toolchain_pins(
+    go_mod_text, dockerfile_text, actual_go, scanner_go
+):
+    go_match = re.search(r"(?m)^go\s+(\d+\.\d+\.\d+)\s*$", go_mod_text)
+    if not go_match:
+        raise AuditError("go.mod must pin a full Go patch version")
+    expected = "go" + go_match.group(1)
+
+    image_match = re.search(
+        r"(?m)^ARG\s+GO_IMAGE=golang:(\d+\.\d+\.\d+)-[^\s]+\s*$",
+        dockerfile_text,
+    )
+    if not image_match:
+        raise AuditError("Dockerfile must pin a patch-level golang GO_IMAGE")
+    docker_go = "go" + image_match.group(1)
+    if docker_go != expected:
+        raise AuditError(
+            f"Docker Go image uses {docker_go}, but go.mod requires {expected}"
+        )
+    if actual_go != expected:
+        raise AuditError(
+            f"running Go toolchain is {actual_go}, but shipped version is {expected}"
+        )
+    if scanner_go != expected:
+        raise AuditError(
+            f"govulncheck scanner was built with {scanner_go}, expected {expected}"
+        )
+    return expected
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--findings", required=True)
+    parser.add_argument("--exceptions", required=True)
+    parser.add_argument("--go-mod", required=True)
+    parser.add_argument("--dockerfile", required=True)
+    parser.add_argument("--actual-go", required=True)
+    parser.add_argument("--scanner-go", required=True)
+    parser.add_argument("--scanner-version", required=True)
+    parser.add_argument("--today", default=date.today().isoformat())
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        today = date.fromisoformat(args.today)
+        go_mod_text = Path(args.go_mod).read_text(encoding="utf-8")
+        dockerfile_text = Path(args.dockerfile).read_text(encoding="utf-8")
+        expected_go = validate_toolchain_pins(
+            go_mod_text, dockerfile_text, args.actual_go, args.scanner_go
+        )
+        documents = read_json_stream(args.findings)
+        validate_scan_metadata(documents, expected_go, args.scanner_version)
+        reachable = reachable_ids(documents)
+        baseline = json.loads(Path(args.exceptions).read_text(encoding="utf-8"))
+        validate_baseline(reachable, baseline, today)
+    except (AuditError, OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"Go vulnerability audit failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Go vulnerability audit passed: {len(reachable)} reviewed reachable finding(s) "
+        f"under {expected_go}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_go_vulnerability_audit.py
+++ b/scripts/check_go_vulnerability_audit.py
@@ -5,12 +5,20 @@ import argparse
 import json
 import re
 import sys
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
 
 class AuditError(ValueError):
     pass
+
+
+@dataclass(frozen=True)
+class ReachabilityScope:
+    finding_id: str
+    affected_module: str
+    project_trace: tuple
 
 
 def read_json_stream(path):
@@ -28,7 +36,7 @@ def read_json_stream(path):
     return documents
 
 
-def reachable_ids(documents):
+def reachable_scopes(documents):
     project_module = None
     for document in documents:
         sbom = document.get("SBOM")
@@ -46,10 +54,27 @@ def reachable_ids(documents):
         trace = finding.get("trace") or []
         if not trace or not trace[0].get("function"):
             continue
-        if any(frame.get("module") == project_module for frame in trace):
-            finding_id = finding.get("osv")
-            if finding_id:
-                reachable.add(finding_id)
+        project_frames = [
+            frame for frame in trace if frame.get("module") == project_module
+        ]
+        if not project_frames:
+            continue
+        finding_id = finding.get("osv")
+        affected_module = trace[0].get("module")
+        if not finding_id or not affected_module:
+            raise AuditError("reachable finding has incomplete ID or affected module")
+        project_trace = []
+        for frame in project_frames:
+            package = frame.get("package")
+            function = frame.get("function")
+            if not package or not function:
+                raise AuditError(
+                    f"reachable finding {finding_id} has an incomplete project frame"
+                )
+            project_trace.append((package, function))
+        reachable.add(
+            ReachabilityScope(finding_id, affected_module, tuple(project_trace))
+        )
     return reachable
 
 
@@ -68,9 +93,34 @@ def _required_date(entry, field, category):
         raise AuditError(f"{category} entry has invalid {field}: {value}") from exc
 
 
+def _allowed_project_traces(entry, category):
+    raw_traces = entry.get("allowed_project_traces")
+    if not isinstance(raw_traces, list) or not raw_traces:
+        raise AuditError(f"{category} entry requires allowed_project_traces")
+    traces = set()
+    for raw_trace in raw_traces:
+        if not isinstance(raw_trace, list) or not raw_trace:
+            raise AuditError(f"{category} allowed project traces must be non-empty arrays")
+        trace = []
+        for frame in raw_trace:
+            if not isinstance(frame, dict):
+                raise AuditError(f"{category} project trace frames must be objects")
+            trace.append(
+                (
+                    _required_text(frame, "package", f"{category} project trace"),
+                    _required_text(frame, "function", f"{category} project trace"),
+                )
+            )
+        normalized = tuple(trace)
+        if normalized in traces:
+            raise AuditError(f"{category} contains a duplicate allowed project trace")
+        traces.add(normalized)
+    return traces
+
+
 def validate_baseline(reachable, baseline, today):
-    if baseline.get("schema_version") != 1:
-        raise AuditError("exception baseline schema_version must be 1")
+    if baseline.get("schema_version") != 2:
+        raise AuditError("exception baseline schema_version must be 2")
 
     categories = (
         ("accepted_risks", "accepted risk", "review_on"),
@@ -87,25 +137,52 @@ def validate_baseline(reachable, baseline, today):
             finding_id = _required_text(entry, "id", label)
             _required_text(entry, "owner", label)
             _required_text(entry, "rationale", label)
+            affected_module = _required_text(entry, "affected_module", label)
             deadline = _required_date(entry, date_field, label)
+            allowed_traces = None
+            if label == "accepted risk":
+                allowed_traces = _allowed_project_traces(entry, label)
             if finding_id in entries_by_id:
                 raise AuditError(f"duplicate exception for {finding_id}")
-            entries_by_id[finding_id] = (label, deadline)
+            entries_by_id[finding_id] = (
+                label,
+                deadline,
+                affected_module,
+                allowed_traces,
+            )
 
+    reachable_ids = {scope.finding_id for scope in reachable}
     approved = set(entries_by_id)
-    unapproved = sorted(reachable - approved)
+    unapproved = sorted(reachable_ids - approved)
     if unapproved:
         raise AuditError(
             "unapproved reachable Go vulnerabilities: " + ", ".join(unapproved)
         )
-    stale = sorted(approved - reachable)
+    stale = sorted(approved - reachable_ids)
     if stale:
         raise AuditError(
             "baseline entries are no longer reachable and must be removed: "
             + ", ".join(stale)
         )
 
-    for finding_id, (label, deadline) in entries_by_id.items():
+    for finding_id, entry in entries_by_id.items():
+        label, deadline, affected_module, allowed_traces = entry
+        actual_scopes = {
+            scope for scope in reachable if scope.finding_id == finding_id
+        }
+        actual_modules = {scope.affected_module for scope in actual_scopes}
+        if actual_modules != {affected_module}:
+            raise AuditError(
+                f"affected module scope for {finding_id} changed: "
+                f"got {', '.join(sorted(actual_modules))}, expected {affected_module}"
+            )
+        if allowed_traces is not None:
+            actual_traces = {scope.project_trace for scope in actual_scopes}
+            if actual_traces != allowed_traces:
+                raise AuditError(
+                    f"accepted risk reachability scope for {finding_id} changed; "
+                    "review every project symbol path before updating the baseline"
+                )
         if today < deadline:
             continue
         if label == "temporary deferral":
@@ -192,7 +269,7 @@ def main():
         )
         documents = read_json_stream(args.findings)
         validate_scan_metadata(documents, expected_go, args.scanner_version)
-        reachable = reachable_ids(documents)
+        reachable = reachable_scopes(documents)
         baseline = json.loads(Path(args.exceptions).read_text(encoding="utf-8"))
         validate_baseline(reachable, baseline, today)
     except (AuditError, OSError, json.JSONDecodeError, ValueError) as exc:
@@ -200,7 +277,8 @@ def main():
         return 1
 
     print(
-        f"Go vulnerability audit passed: {len(reachable)} reviewed reachable finding(s) "
+        f"Go vulnerability audit passed: "
+        f"{len({scope.finding_id for scope in reachable})} reviewed reachable finding(s) "
         f"under {expected_go}."
     )
     return 0

--- a/scripts/test_check_go_vulnerability_audit.py
+++ b/scripts/test_check_go_vulnerability_audit.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
 import pathlib
+import subprocess
+import sys
+import tempfile
 import unittest
 from datetime import date
 
 MODULE_PATH = pathlib.Path(__file__).with_name("check_go_vulnerability_audit.py")
 SPEC = importlib.util.spec_from_file_location("check_go_vulnerability_audit", MODULE_PATH)
 AUDIT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = AUDIT
 SPEC.loader.exec_module(AUDIT)
+
+
+def scope(finding_id, affected_module, *project_frames):
+    return AUDIT.ReachabilityScope(finding_id, affected_module, project_frames)
 
 
 class ReachableFindingsTests(unittest.TestCase):
@@ -30,19 +39,37 @@ class ReachableFindingsTests(unittest.TestCase):
             },
         ]
 
-        self.assertEqual(AUDIT.reachable_ids(documents), {"GO-REACHABLE"})
+        self.assertEqual(
+            AUDIT.reachable_scopes(documents),
+            {
+                scope(
+                    "GO-REACHABLE",
+                    "stdlib",
+                    ("example.com/project/client", "Fetch"),
+                )
+            },
+        )
 
 
 class BaselineTests(unittest.TestCase):
     def setUp(self):
         self.baseline = {
-            "schema_version": 1,
+            "schema_version": 2,
             "accepted_risks": [
                 {
                     "id": "GO-ACCEPTED",
                     "owner": "security",
                     "rationale": "Not applicable to the terminal sink.",
                     "review_on": "2027-01-25",
+                    "affected_module": "example.com/renderer",
+                    "allowed_project_traces": [
+                        [
+                            {
+                                "package": "example.com/project/terminal",
+                                "function": "RenderANSI",
+                            }
+                        ]
+                    ],
                 }
             ],
             "temporary_deferrals": [
@@ -51,19 +78,30 @@ class BaselineTests(unittest.TestCase):
                     "owner": "security",
                     "rationale": "Requires a separately reviewed toolchain upgrade.",
                     "expires_on": "2026-08-15",
+                    "affected_module": "stdlib",
                 }
             ],
         }
+        self.scopes = {
+            scope(
+                "GO-ACCEPTED",
+                "example.com/renderer",
+                ("example.com/project/terminal", "RenderANSI"),
+            ),
+            scope(
+                "GO-DEFERRED",
+                "stdlib",
+                ("example.com/project/client", "Fetch"),
+            ),
+        }
 
     def test_exact_unexpired_baseline_passes(self):
-        AUDIT.validate_baseline(
-            {"GO-ACCEPTED", "GO-DEFERRED"}, self.baseline, date(2026, 7, 25)
-        )
+        AUDIT.validate_baseline(self.scopes, self.baseline, date(2026, 7, 25))
 
     def test_new_reachable_finding_fails(self):
         with self.assertRaisesRegex(AUDIT.AuditError, "unapproved reachable"):
             AUDIT.validate_baseline(
-                {"GO-ACCEPTED", "GO-DEFERRED", "GO-NEW"},
+                self.scopes | {scope("GO-NEW", "stdlib", ("example.com/project", "Use"))},
                 self.baseline,
                 date(2026, 7, 25),
             )
@@ -71,24 +109,189 @@ class BaselineTests(unittest.TestCase):
     def test_stale_baseline_entry_fails(self):
         with self.assertRaisesRegex(AUDIT.AuditError, "no longer reachable"):
             AUDIT.validate_baseline(
-                {"GO-ACCEPTED"}, self.baseline, date(2026, 7, 25)
+                {next(item for item in self.scopes if item.finding_id == "GO-ACCEPTED")},
+                self.baseline,
+                date(2026, 7, 25),
             )
 
     def test_temporary_deferral_fails_on_expiry_date(self):
         with self.assertRaisesRegex(AUDIT.AuditError, "expired"):
             AUDIT.validate_baseline(
-                {"GO-ACCEPTED", "GO-DEFERRED"},
-                self.baseline,
-                date(2026, 8, 15),
+                self.scopes, self.baseline, date(2026, 8, 15),
             )
 
     def test_accepted_risk_fails_when_review_is_due(self):
         with self.assertRaisesRegex(AUDIT.AuditError, "review is due"):
             AUDIT.validate_baseline(
-                {"GO-ACCEPTED", "GO-DEFERRED"},
-                self.baseline,
-                date(2027, 1, 25),
+                self.scopes, self.baseline, date(2027, 1, 25),
             )
+
+    def test_same_id_new_accepted_risk_path_fails(self):
+        changed = self.scopes | {
+            scope(
+                "GO-ACCEPTED",
+                "example.com/renderer",
+                ("example.com/project/browser", "RenderHTML"),
+            )
+        }
+        with self.assertRaisesRegex(AUDIT.AuditError, "reachability scope"):
+            AUDIT.validate_baseline(changed, self.baseline, date(2026, 7, 25))
+
+    def test_same_id_new_affected_module_fails(self):
+        changed = self.scopes | {
+            scope(
+                "GO-DEFERRED",
+                "golang.org/x/net",
+                ("example.com/project/client", "FetchHTTP2"),
+            )
+        }
+        with self.assertRaisesRegex(AUDIT.AuditError, "affected module"):
+            AUDIT.validate_baseline(changed, self.baseline, date(2026, 7, 25))
+
+
+class CheckerEntryPointTests(unittest.TestCase):
+    def run_checker(self, findings, baseline):
+        documents = [
+            {
+                "config": {
+                    "scanner_name": "govulncheck",
+                    "scanner_version": "v1.1.4",
+                    "go_version": "go1.24.13",
+                    "scan_level": "symbol",
+                    "scan_mode": "source",
+                }
+            },
+            {"SBOM": {"modules": [{"path": "github.com/awebai/aw"}]}},
+            *({"finding": finding} for finding in findings),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "findings.json").write_text(
+                "\n".join(json.dumps(document) for document in documents) + "\n",
+                encoding="utf-8",
+            )
+            (root / "exceptions.json").write_text(
+                json.dumps(baseline), encoding="utf-8"
+            )
+            (root / "go.mod").write_text(
+                "module github.com/awebai/aw\n\ngo 1.24.13\n", encoding="utf-8"
+            )
+            (root / "Dockerfile").write_text(
+                "ARG GO_IMAGE=golang:1.24.13-bookworm\n", encoding="utf-8"
+            )
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--findings",
+                    str(root / "findings.json"),
+                    "--exceptions",
+                    str(root / "exceptions.json"),
+                    "--go-mod",
+                    str(root / "go.mod"),
+                    "--dockerfile",
+                    str(root / "Dockerfile"),
+                    "--actual-go",
+                    "go1.24.13",
+                    "--scanner-go",
+                    "go1.24.13",
+                    "--scanner-version",
+                    "v1.1.4",
+                    "--today",
+                    "2026-07-25",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_same_id_browser_path_fails_through_entry_point(self):
+        current_trace = [
+            {
+                "module": "github.com/yuin/goldmark",
+                "package": "github.com/yuin/goldmark/renderer/html",
+                "function": "renderLink",
+            },
+            {
+                "module": "github.com/awebai/aw",
+                "package": "github.com/awebai/aw/run",
+                "function": "renderCodexAssistantTextWithOptions",
+            },
+        ]
+        browser_trace = current_trace + [
+            {
+                "module": "github.com/awebai/aw",
+                "package": "github.com/awebai/aw/cmd/aweb-a2a-gw",
+                "function": "RenderBrowserResponse",
+            }
+        ]
+        baseline = {
+            "schema_version": 2,
+            "accepted_risks": [
+                {
+                    "id": "GO-2026-5320",
+                    "owner": "security",
+                    "rationale": "The reviewed path terminates in ANSI output.",
+                    "review_on": "2027-01-25",
+                    "affected_module": "github.com/yuin/goldmark",
+                    "allowed_project_traces": [
+                        [
+                            {
+                                "package": "github.com/awebai/aw/run",
+                                "function": "renderCodexAssistantTextWithOptions",
+                            }
+                        ]
+                    ],
+                }
+            ],
+            "temporary_deferrals": [],
+        }
+        result = self.run_checker(
+            [
+                {"osv": "GO-2026-5320", "trace": current_trace},
+                {"osv": "GO-2026-5320", "trace": browser_trace},
+            ],
+            baseline,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("reachability scope", result.stderr)
+
+    def test_same_id_x_net_variant_fails_through_entry_point(self):
+        def finding(module, package, function):
+            return {
+                "osv": "GO-2026-4918",
+                "trace": [
+                    {"module": module, "package": package, "function": function},
+                    {
+                        "module": "github.com/awebai/aw",
+                        "package": "github.com/awebai/aw/awid",
+                        "function": "DoRawWithHeaders",
+                    },
+                ],
+            }
+
+        baseline = {
+            "schema_version": 2,
+            "accepted_risks": [],
+            "temporary_deferrals": [
+                {
+                    "id": "GO-2026-4918",
+                    "owner": "security",
+                    "rationale": "The standard-library fix requires Go 1.25.10.",
+                    "expires_on": "2026-08-15",
+                    "affected_module": "stdlib",
+                }
+            ],
+        }
+        result = self.run_checker(
+            [
+                finding("stdlib", "net/http", "Do"),
+                finding("golang.org/x/net", "golang.org/x/net/http2", "processSettings"),
+            ],
+            baseline,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("affected module", result.stderr)
 
 
 class ScanMetadataTests(unittest.TestCase):

--- a/scripts/test_check_go_vulnerability_audit.py
+++ b/scripts/test_check_go_vulnerability_audit.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+import importlib.util
+import pathlib
+import unittest
+from datetime import date
+
+MODULE_PATH = pathlib.Path(__file__).with_name("check_go_vulnerability_audit.py")
+SPEC = importlib.util.spec_from_file_location("check_go_vulnerability_audit", MODULE_PATH)
+AUDIT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUDIT)
+
+
+class ReachableFindingsTests(unittest.TestCase):
+    def test_only_symbol_traces_reaching_project_code_are_reported(self):
+        documents = [
+            {"SBOM": {"modules": [{"path": "example.com/project"}]}},
+            {"finding": {"osv": "GO-MODULE-ONLY", "trace": [{"module": "stdlib"}]}},
+            {
+                "finding": {
+                    "osv": "GO-REACHABLE",
+                    "trace": [
+                        {"module": "stdlib", "package": "net/http", "function": "Do"},
+                        {
+                            "module": "example.com/project",
+                            "package": "example.com/project/client",
+                            "function": "Fetch",
+                        },
+                    ],
+                }
+            },
+        ]
+
+        self.assertEqual(AUDIT.reachable_ids(documents), {"GO-REACHABLE"})
+
+
+class BaselineTests(unittest.TestCase):
+    def setUp(self):
+        self.baseline = {
+            "schema_version": 1,
+            "accepted_risks": [
+                {
+                    "id": "GO-ACCEPTED",
+                    "owner": "security",
+                    "rationale": "Not applicable to the terminal sink.",
+                    "review_on": "2027-01-25",
+                }
+            ],
+            "temporary_deferrals": [
+                {
+                    "id": "GO-DEFERRED",
+                    "owner": "security",
+                    "rationale": "Requires a separately reviewed toolchain upgrade.",
+                    "expires_on": "2026-08-15",
+                }
+            ],
+        }
+
+    def test_exact_unexpired_baseline_passes(self):
+        AUDIT.validate_baseline(
+            {"GO-ACCEPTED", "GO-DEFERRED"}, self.baseline, date(2026, 7, 25)
+        )
+
+    def test_new_reachable_finding_fails(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "unapproved reachable"):
+            AUDIT.validate_baseline(
+                {"GO-ACCEPTED", "GO-DEFERRED", "GO-NEW"},
+                self.baseline,
+                date(2026, 7, 25),
+            )
+
+    def test_stale_baseline_entry_fails(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "no longer reachable"):
+            AUDIT.validate_baseline(
+                {"GO-ACCEPTED"}, self.baseline, date(2026, 7, 25)
+            )
+
+    def test_temporary_deferral_fails_on_expiry_date(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "expired"):
+            AUDIT.validate_baseline(
+                {"GO-ACCEPTED", "GO-DEFERRED"},
+                self.baseline,
+                date(2026, 8, 15),
+            )
+
+    def test_accepted_risk_fails_when_review_is_due(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "review is due"):
+            AUDIT.validate_baseline(
+                {"GO-ACCEPTED", "GO-DEFERRED"},
+                self.baseline,
+                date(2027, 1, 25),
+            )
+
+
+class ScanMetadataTests(unittest.TestCase):
+    def test_symbol_source_scan_from_pinned_scanner_passes(self):
+        AUDIT.validate_scan_metadata(
+            [
+                {
+                    "config": {
+                        "scanner_name": "govulncheck",
+                        "scanner_version": "v1.1.4",
+                        "go_version": "go1.24.13",
+                        "scan_level": "symbol",
+                        "scan_mode": "source",
+                    }
+                }
+            ],
+            expected_go="go1.24.13",
+            expected_scanner="v1.1.4",
+        )
+
+    def test_package_level_scan_is_rejected(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "symbol-level source scan"):
+            AUDIT.validate_scan_metadata(
+                [
+                    {
+                        "config": {
+                            "scanner_name": "govulncheck",
+                            "scanner_version": "v1.1.4",
+                            "go_version": "go1.24.13",
+                            "scan_level": "package",
+                            "scan_mode": "source",
+                        }
+                    }
+                ],
+                expected_go="go1.24.13",
+                expected_scanner="v1.1.4",
+            )
+
+
+class ToolchainPinTests(unittest.TestCase):
+    def test_repository_pins_patched_go_1_24_toolchain(self):
+        repo = pathlib.Path(__file__).resolve().parents[1]
+        expected = AUDIT.validate_toolchain_pins(
+            (repo / "cli/go/go.mod").read_text(encoding="utf-8"),
+            (repo / "cli/go/Dockerfile.a2a-gw").read_text(encoding="utf-8"),
+            actual_go="go1.24.13",
+            scanner_go="go1.24.13",
+        )
+        self.assertEqual(expected, "go1.24.13")
+
+    def test_matching_source_container_runtime_and_scanner_pass(self):
+        expected = AUDIT.validate_toolchain_pins(
+            "module example.com/project\n\ngo 1.24.13\n",
+            "ARG GO_IMAGE=golang:1.24.13-bookworm\n",
+            actual_go="go1.24.13",
+            scanner_go="go1.24.13",
+        )
+        self.assertEqual(expected, "go1.24.13")
+
+    def test_docker_pin_drift_fails(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "Docker Go image"):
+            AUDIT.validate_toolchain_pins(
+                "module example.com/project\n\ngo 1.24.13\n",
+                "ARG GO_IMAGE=golang:1.24.2-bookworm\n",
+                actual_go="go1.24.13",
+                scanner_go="go1.24.13",
+            )
+
+    def test_runner_toolchain_drift_fails(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "running Go toolchain"):
+            AUDIT.validate_toolchain_pins(
+                "module example.com/project\n\ngo 1.24.13\n",
+                "ARG GO_IMAGE=golang:1.24.13-bookworm\n",
+                actual_go="go1.26.4",
+                scanner_go="go1.24.13",
+            )
+
+    def test_scanner_build_toolchain_drift_fails(self):
+        with self.assertRaisesRegex(AUDIT.AuditError, "scanner was built"):
+            AUDIT.validate_toolchain_pins(
+                "module example.com/project\n\ngo 1.24.13\n",
+                "ARG GO_IMAGE=golang:1.24.13-bookworm\n",
+                actual_go="go1.24.13",
+                scanner_go="go1.26.4",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bump the shipped Go 1.24 patch from 1.24.2 to 1.24.13 in go.mod and the A2A gateway builder image
- add a symbol-level govulncheck gate that runs under the exact shipped toolchain and fails on source/container/scanner drift
- baseline only reviewed reachable findings, failing on new IDs, stale entries, and due review/expiry dates
- retain two terminal-sink HTML/XSS accepted risks; defer eleven Go-1.25-only standard-library findings until 2026-08-15
- archive raw govulncheck JSON in CI

## Measured result
- Go 1.24.2: 29 code-reachable findings
- Go 1.24.13: 13 code-reachable findings (exactly 16 removed)
- no Go 1.25 upgrade or dependency bump in this change

## Local verification
- pinned gate under Go 1.24.13: PASS, 13 reviewed findings
- gate self-tests: 13 PASS
- go test -race ./... -count=1 under Go 1.24.13: PASS, all 14 packages
- freshness gate: PASS
- local Docker build from golang:1.24.13-bookworm: PASS; extracted binary reports go1.24.13
