### PR TITLE
fix(run): acknowledge only presented chat batches

### DIFF
--- a/cli/go/cmd/aw/run_dispatch.go
+++ b/cli/go/cmd/aw/run_dispatch.go
@@ -15,7 +15,10 @@ import (
 	awrun "github.com/awebai/aw/run"
 )
 
-const maxChatMessagesPerWake = 20
+const (
+	maxChatMessagesPerWake = 20
+	maxChatHistoryFetch    = 2000
+)
 
 type runWakeResolution struct {
 	Skip          bool
@@ -136,18 +139,16 @@ func resolveChatWakeForAlias(ctx context.Context, client *aweb.Client, selfAlias
 	}
 	messageID := strings.TrimSpace(evt.MessageID)
 	if messageID != "" {
-		limit := evt.UnreadCount
-		if limit <= 0 {
-			limit = 20
-		} else if limit > 100 {
-			limit = 100
+		limit, err := unreadChatHistoryLimit(evt.UnreadCount)
+		if err != nil {
+			return runWakeResolution{}, err
 		}
 		history, err := client.ChatHistory(ctx, awid.ChatHistoryParams{
 			SessionID:  sessionID,
 			UnreadOnly: true,
 			Limit:      limit,
 		})
-		if err == nil {
+		if err == nil && requireCompleteUnreadChatHistory(evt.UnreadCount, limit, len(history.Messages)) == nil {
 			filtered := chat.FilterDeliveredMessages(history.Messages)
 			presented := incomingChatMessages(filtered, selfAlias, selfIdentityDIDs(client)...)
 			if len(presented) > 0 {
@@ -170,13 +171,16 @@ func resolveChatWakeForAlias(ctx context.Context, client *aweb.Client, selfAlias
 		if alias == "" {
 			alias = strings.TrimSpace(pending.LastFrom)
 		}
-		// Mark as read — fetch unread history to find the last message ID.
-		histResp, _ := client.ChatHistory(ctx, awid.ChatHistoryParams{
+		limit, err := unreadChatHistoryLimit(pending.UnreadCount)
+		if err != nil {
+			return runWakeResolution{}, err
+		}
+		histResp, historyErr := client.ChatHistory(ctx, awid.ChatHistoryParams{
 			SessionID:  sessionID,
 			UnreadOnly: true,
-			Limit:      100,
+			Limit:      limit,
 		})
-		if histResp != nil {
+		if historyErr == nil && histResp != nil && requireCompleteUnreadChatHistory(pending.UnreadCount, limit, len(histResp.Messages)) == nil {
 			filtered := chat.FilterDeliveredMessages(histResp.Messages)
 			presented := incomingChatMessages(filtered, selfAlias, selfIdentityDIDs(client)...)
 			if len(presented) > 0 {
@@ -290,6 +294,28 @@ func pendingChatSenderFromSelf(pending awid.ChatPendingItem, selfAlias string, s
 		return false
 	}
 	return strings.TrimSpace(selfAlias) != "" && strings.EqualFold(strings.TrimSpace(pending.LastFrom), strings.TrimSpace(selfAlias))
+}
+
+// The history API applies LIMIT to newest rows. Fetch the complete unread set
+// before selecting its oldest bounded prefix, or a watermark through the
+// selected suffix would silently acknowledge older messages never presented.
+func unreadChatHistoryLimit(unreadCount int) (int, error) {
+	if unreadCount > maxChatHistoryFetch {
+		return 0, fmt.Errorf("chat unread backlog %d exceeds safe history fetch limit %d", unreadCount, maxChatHistoryFetch)
+	}
+	// Always request the maximum: the event count can be stale if another
+	// message arrives before the history fetch.
+	return maxChatHistoryFetch, nil
+}
+
+func requireCompleteUnreadChatHistory(expectedCount, requestedLimit, fetchedCount int) error {
+	if expectedCount > fetchedCount {
+		return fmt.Errorf("chat history returned %d of %d unread messages; refusing to acknowledge an omitted prefix", fetchedCount, expectedCount)
+	}
+	if fetchedCount == requestedLimit {
+		return fmt.Errorf("chat history reached limit %d; refusing to acknowledge a potentially omitted prefix", requestedLimit)
+	}
+	return nil
 }
 
 func incomingChatMessages(messages []awid.ChatMessage, selfAlias string, selfDIDs ...string) []awid.ChatMessage {

--- a/cli/go/cmd/aw/run_dispatch.go
+++ b/cli/go/cmd/aw/run_dispatch.go
@@ -15,6 +15,8 @@ import (
 	awrun "github.com/awebai/aw/run"
 )
 
+const maxChatMessagesPerWake = 20
+
 type runWakeResolution struct {
 	Skip          bool
 	CycleContext  string
@@ -147,37 +149,11 @@ func resolveChatWakeForAlias(ctx context.Context, client *aweb.Client, selfAlias
 		})
 		if err == nil {
 			filtered := chat.FilterDeliveredMessages(history.Messages)
-			if ids := chat.DeliveredMessageIDs(history.Messages); len(ids) > 0 {
-				_ = chat.SaveDeliveredIDs(ids)
+			presented := incomingChatMessages(filtered, selfAlias, selfIdentityDIDs(client)...)
+			if len(presented) > 0 {
+				return chatWakeResolution(client, sessionID, presented, evt), nil
 			}
-			markChatHistoryRead(ctx, client, sessionID, history.Messages)
-			for _, msg := range filtered {
-				if strings.TrimSpace(msg.MessageID) != messageID {
-					continue
-				}
-				if chatMessageFromSelf(msg, selfAlias, selfIdentityDIDs(client)...) {
-					return runWakeResolution{Skip: true}, nil
-				}
-				return runWakeResolution{
-					CycleContext: formatIncomingChatContext(
-						preferredIdentityDisplayLabel(
-							strings.TrimSpace(msg.FromAgent),
-							strings.TrimSpace(msg.FromAddress),
-							strings.TrimSpace(msg.FromStableID),
-							strings.TrimSpace(msg.FromDID),
-							preferredIdentityDisplayLabel(
-								strings.TrimSpace(evt.FromAlias),
-								strings.TrimSpace(evt.FromAddress),
-								strings.TrimSpace(evt.FromStableID),
-								strings.TrimSpace(evt.FromDID),
-								"",
-							),
-						),
-						msg.Body,
-					),
-				}, nil
-			}
-			if len(history.Messages) > 0 && len(filtered) == 0 {
+			if len(history.Messages) > 0 {
 				return runWakeResolution{Skip: true}, nil
 			}
 		}
@@ -202,29 +178,9 @@ func resolveChatWakeForAlias(ctx context.Context, client *aweb.Client, selfAlias
 		})
 		if histResp != nil {
 			filtered := chat.FilterDeliveredMessages(histResp.Messages)
-			if ids := chat.DeliveredMessageIDs(histResp.Messages); len(ids) > 0 {
-				_ = chat.SaveDeliveredIDs(ids)
-			}
-			markChatHistoryRead(ctx, client, sessionID, histResp.Messages)
-			if latest := latestIncomingChatMessage(filtered, selfAlias, selfIdentityDIDs(client)...); latest != nil {
-				return runWakeResolution{
-					CycleContext: formatIncomingChatContext(
-						preferredIdentityDisplayLabel(
-							strings.TrimSpace(latest.FromAgent),
-							strings.TrimSpace(latest.FromAddress),
-							strings.TrimSpace(latest.FromStableID),
-							strings.TrimSpace(latest.FromDID),
-							preferredIdentityDisplayLabel(
-								strings.TrimSpace(evt.FromAlias),
-								strings.TrimSpace(evt.FromAddress),
-								strings.TrimSpace(evt.FromStableID),
-								strings.TrimSpace(evt.FromDID),
-								"",
-							),
-						),
-						latest.Body,
-					),
-				}, nil
+			presented := incomingChatMessages(filtered, selfAlias, selfIdentityDIDs(client)...)
+			if len(presented) > 0 {
+				return chatWakeResolution(client, sessionID, presented, evt), nil
 			}
 			if len(histResp.Messages) > 0 {
 				return runWakeResolution{Skip: true}, nil
@@ -336,14 +292,57 @@ func pendingChatSenderFromSelf(pending awid.ChatPendingItem, selfAlias string, s
 	return strings.TrimSpace(selfAlias) != "" && strings.EqualFold(strings.TrimSpace(pending.LastFrom), strings.TrimSpace(selfAlias))
 }
 
-func latestIncomingChatMessage(messages []awid.ChatMessage, selfAlias string, selfDIDs ...string) *awid.ChatMessage {
-	for i := len(messages) - 1; i >= 0; i-- {
-		if chatMessageFromSelf(messages[i], selfAlias, selfDIDs...) {
+func incomingChatMessages(messages []awid.ChatMessage, selfAlias string, selfDIDs ...string) []awid.ChatMessage {
+	incoming := make([]awid.ChatMessage, 0, len(messages))
+	for _, message := range messages {
+		if chatMessageFromSelf(message, selfAlias, selfDIDs...) {
 			continue
 		}
-		return &messages[i]
+		incoming = append(incoming, message)
+		if len(incoming) == maxChatMessagesPerWake {
+			break
+		}
 	}
-	return nil
+	return incoming
+}
+
+func chatWakeResolution(client *aweb.Client, sessionID string, messages []awid.ChatMessage, evt awid.AgentEvent) runWakeResolution {
+	contexts := make([]string, 0, len(messages))
+	for _, message := range messages {
+		contexts = append(contexts, formatIncomingChatContext(
+			preferredIdentityDisplayLabel(
+				strings.TrimSpace(message.FromAgent),
+				strings.TrimSpace(message.FromAddress),
+				strings.TrimSpace(message.FromStableID),
+				strings.TrimSpace(message.FromDID),
+				preferredIdentityDisplayLabel(
+					strings.TrimSpace(evt.FromAlias),
+					strings.TrimSpace(evt.FromAddress),
+					strings.TrimSpace(evt.FromStableID),
+					strings.TrimSpace(evt.FromDID),
+					"",
+				),
+			),
+			message.Body,
+		))
+	}
+
+	resolution := runWakeResolution{CycleContext: joinPromptSections(contexts...)}
+	presentedIDs := chat.DeliveredMessageIDs(messages)
+	if len(presentedIDs) == 0 {
+		return resolution
+	}
+	lastPresentedID := presentedIDs[len(presentedIDs)-1]
+	resolution.AfterDelivery = func(deliveryCtx context.Context) error {
+		// A failed server acknowledgement must leave local suppression untouched
+		// so the unread batch remains retryable. Reversing this order recreates
+		// the permanent-loss bug this transaction prevents.
+		if err := markChatMessageRead(deliveryCtx, client, sessionID, lastPresentedID); err != nil {
+			return err
+		}
+		return chat.SaveDeliveredIDs(presentedIDs)
+	}
+	return resolution
 }
 
 func resolveMailWakeForAlias(ctx context.Context, client *aweb.Client, selfAlias string, evt awid.AgentEvent) (runWakeResolution, error) {
@@ -506,25 +505,24 @@ func formatIncomingMailBlock(head string, subject string, body string) string {
 	return strings.Join(formatted, "\n")
 }
 
-func markChatHistoryRead(ctx context.Context, client *aweb.Client, sessionID string, messages []awid.ChatMessage) {
-	if len(messages) == 0 {
-		return
+func markChatMessageRead(ctx context.Context, client *aweb.Client, sessionID, messageID string) error {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return nil
 	}
-	lastMsgID := messages[len(messages)-1].MessageID
-	if lastMsgID != "" {
-		req := &awid.ChatMarkReadRequest{UpToMessageID: lastMsgID}
-		if _, err := client.ChatMarkRead(ctx, sessionID, req); err == nil {
-			return
-		}
-		timer := time.NewTimer(100 * time.Millisecond)
-		defer timer.Stop()
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-		}
-		_, _ = client.ChatMarkRead(ctx, sessionID, req)
+	req := &awid.ChatMarkReadRequest{UpToMessageID: messageID}
+	if _, err := client.ChatMarkRead(ctx, sessionID, req); err == nil {
+		return nil
 	}
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+	}
+	_, err := client.ChatMarkRead(ctx, sessionID, req)
+	return err
 }
 
 func commBodyLines(body string) []string {

--- a/cli/go/cmd/aw/run_dispatch_test.go
+++ b/cli/go/cmd/aw/run_dispatch_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -502,10 +504,11 @@ func TestFormatFallbackCommsContextPrefersFromAddress(t *testing.T) {
 	}
 }
 
-// TestResolveChatWakeMarksRead verifies that resolveChatWake marks messages
-// as read after fetching the pending conversation.
-func TestResolveChatWakeMarksRead(t *testing.T) {
-	_ = deliveredIDsTestPath(t)
+// TestResolveChatWakeMarksReadAfterDelivery verifies that resolving a chat wake
+// leaves both suppression layers untouched until the provider accepts the
+// prompt, matching the mail delivery contract.
+func TestResolveChatWakeMarksReadAfterDelivery(t *testing.T) {
+	deliveredDir := deliveredIDsTestPath(t)
 
 	var markedReadSessionID string
 	var markedReadUpTo string
@@ -525,7 +528,6 @@ func TestResolveChatWakeMarksRead(t *testing.T) {
 				},
 			})
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
-			// /v1/chat/sessions/{id}/read → parts: ["", "v1", "chat", "sessions", "{id}", "read"]
 			parts := strings.Split(r.URL.Path, "/")
 			markedReadSessionID = parts[4]
 			var req awid.ChatMarkReadRequest
@@ -550,11 +552,186 @@ func TestResolveChatWakeMarksRead(t *testing.T) {
 	if result.Skip {
 		t.Fatal("should not skip")
 	}
-	if markedReadSessionID != "s1" {
-		t.Fatalf("expected mark-read for session s1, got %q", markedReadSessionID)
+	if markedReadSessionID != "" {
+		t.Fatalf("chat was marked read before provider delivery: %q", markedReadSessionID)
 	}
-	if markedReadUpTo != "markread-msg-1" {
-		t.Fatalf("expected mark-read up to markread-msg-1, got %q", markedReadUpTo)
+	if delivered, err := chat.LoadDeliveredIDsForDir(deliveredDir); err != nil {
+		t.Fatal(err)
+	} else if len(delivered) != 0 {
+		t.Fatalf("chat was locally suppressed before provider delivery: %#v", delivered)
+	}
+	if result.AfterDelivery == nil {
+		t.Fatal("expected post-delivery chat acknowledgement")
+	}
+	if err := result.AfterDelivery(context.Background()); err != nil {
+		t.Fatalf("post-delivery acknowledgement: %v", err)
+	}
+	if markedReadSessionID != "s1" || markedReadUpTo != "markread-msg-1" {
+		t.Fatalf("mark-read=(%q, %q), want (s1, markread-msg-1)", markedReadSessionID, markedReadUpTo)
+	}
+	if delivered, err := chat.LoadDeliveredIDsForDir(deliveredDir); err != nil {
+		t.Fatal(err)
+	} else if _, ok := delivered["markread-msg-1"]; !ok {
+		t.Fatalf("presented chat was not durably marked: %#v", delivered)
+	}
+}
+
+func TestResolveChatWakePresentsAndAcknowledgesWholeIncomingBatch(t *testing.T) {
+	deliveredDir := deliveredIDsTestPath(t)
+	var markedReadUpTo string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s1/messages"):
+			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: []awid.ChatMessage{
+				{MessageID: "incoming-1", FromAgent: "alice", Body: "first request"},
+				{MessageID: "self-1", FromAgent: "rose", Body: "my earlier reply"},
+				{MessageID: "incoming-2", FromAgent: "bob", Body: "second request"},
+			}})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
+			var req awid.ChatMarkReadRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			markedReadUpTo = req.UpToMessageID
+			json.NewEncoder(w).Encode(awid.ChatMarkReadResponse{Success: true, MessagesMarked: 2})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := mustWebClient(t, server.URL)
+	result, err := resolveChatWakeForAlias(context.Background(), client, "rose", awid.AgentEvent{
+		Type:        awid.AgentEventActionableChat,
+		SessionID:   "s1",
+		MessageID:   "incoming-2",
+		FromAlias:   "bob",
+		UnreadCount: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Skip {
+		t.Fatalf("expected batch delivery, got %+v", result)
+	}
+	for _, body := range []string{"first request", "second request"} {
+		if !strings.Contains(result.CycleContext, body) {
+			t.Fatalf("provider context omitted %q: %q", body, result.CycleContext)
+		}
+	}
+	if strings.Contains(result.CycleContext, "my earlier reply") {
+		t.Fatalf("provider context included self-authored message: %q", result.CycleContext)
+	}
+	if result.AfterDelivery == nil {
+		t.Fatal("expected batch post-delivery acknowledgement")
+	}
+	if err := result.AfterDelivery(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if markedReadUpTo != "incoming-2" {
+		t.Fatalf("marked read up to %q, want incoming-2", markedReadUpTo)
+	}
+	delivered, err := chat.LoadDeliveredIDsForDir(deliveredDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"incoming-1", "incoming-2"} {
+		if _, ok := delivered[id]; !ok {
+			t.Fatalf("presented id %q missing from local delivery store: %#v", id, delivered)
+		}
+	}
+	if _, ok := delivered["self-1"]; ok {
+		t.Fatalf("self-authored id was locally suppressed: %#v", delivered)
+	}
+}
+
+func TestResolveChatWakeBoundsBatchAndLeavesRemainderRetryable(t *testing.T) {
+	const expectedBatchLimit = 20
+	if maxChatMessagesPerWake != expectedBatchLimit {
+		t.Fatalf("maxChatMessagesPerWake=%d, want reviewed bound %d", maxChatMessagesPerWake, expectedBatchLimit)
+	}
+	deliveredDir := deliveredIDsTestPath(t)
+	messages := make([]awid.ChatMessage, expectedBatchLimit+2)
+	for i := range messages {
+		messages[i] = awid.ChatMessage{
+			MessageID: fmt.Sprintf("batch-%02d", i),
+			FromAgent: "alice",
+			Body:      fmt.Sprintf("request-%02d", i),
+		}
+	}
+	acked := -1
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s1/messages"):
+			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: messages[acked+1:]})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
+			var req awid.ChatMarkReadRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			for i := range messages {
+				if messages[i].MessageID == req.UpToMessageID {
+					acked = i
+					break
+				}
+			}
+			json.NewEncoder(w).Encode(awid.ChatMarkReadResponse{Success: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := mustWebClient(t, server.URL)
+	first, err := resolveChatWake(context.Background(), client, awid.AgentEvent{
+		Type:        awid.AgentEventActionableChat,
+		SessionID:   "s1",
+		MessageID:   messages[len(messages)-1].MessageID,
+		FromAlias:   "alice",
+		UnreadCount: len(messages),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < expectedBatchLimit; i++ {
+		if !strings.Contains(first.CycleContext, messages[i].Body) {
+			t.Fatalf("bounded context omitted index %d", i)
+		}
+	}
+	for i := expectedBatchLimit; i < len(messages); i++ {
+		if strings.Contains(first.CycleContext, messages[i].Body) {
+			t.Fatalf("bounded context included index %d", i)
+		}
+	}
+	if first.AfterDelivery == nil {
+		t.Fatal("expected bounded batch acknowledgement")
+	}
+	if err := first.AfterDelivery(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if acked != expectedBatchLimit-1 {
+		t.Fatalf("acked index=%d, want %d", acked, expectedBatchLimit-1)
+	}
+
+	delivered, err := chat.LoadDeliveredIDsForDir(deliveredDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(delivered) != expectedBatchLimit {
+		t.Fatalf("delivered count=%d, want %d", len(delivered), expectedBatchLimit)
+	}
+	second, err := resolveChatWake(context.Background(), client, awid.AgentEvent{
+		Type:        awid.AgentEventActionableChat,
+		SessionID:   "s1",
+		MessageID:   messages[len(messages)-1].MessageID,
+		FromAlias:   "alice",
+		UnreadCount: len(messages) - expectedBatchLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := expectedBatchLimit; i < len(messages); i++ {
+		if !strings.Contains(second.CycleContext, messages[i].Body) {
+			t.Fatalf("remainder context omitted index %d: %q", i, second.CycleContext)
+		}
 	}
 }
 
@@ -1269,7 +1446,51 @@ func TestResolveChatWakeForAliasDoesNotSkipPendingFallbackForDifferentAddressHan
 	}
 }
 
-func TestResolveChatWakeRetriesMarkReadAndCachesDeliveredIDs(t *testing.T) {
+func TestResolveChatWakePropagatesLocalDeliveryMarkFailure(t *testing.T) {
+	deliveredDir := deliveredIDsTestPath(t)
+	deliveredPath := filepath.Join(deliveredDir, ".aw", chat.DeliveredIDsFileName)
+	if err := os.MkdirAll(deliveredPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var markedRead bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s1/messages"):
+			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: []awid.ChatMessage{
+				{MessageID: "persist-failure-1", FromAgent: "alice", Body: "hey"},
+			}})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
+			markedRead = true
+			json.NewEncoder(w).Encode(awid.ChatMarkReadResponse{Success: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := mustWebClient(t, server.URL)
+	resolved, err := resolveChatWake(context.Background(), client, awid.AgentEvent{
+		Type:      awid.AgentEventActionableChat,
+		SessionID: "s1",
+		MessageID: "persist-failure-1",
+		FromAlias: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.AfterDelivery == nil {
+		t.Fatal("expected post-delivery acknowledgement")
+	}
+	if err := resolved.AfterDelivery(context.Background()); err == nil {
+		t.Fatal("expected local delivery-mark error")
+	}
+	if !markedRead {
+		t.Fatal("local persistence was attempted before the upstream read acknowledgement")
+	}
+}
+
+func TestResolveChatWakeFailedMarkReadLeavesMessageRetryable(t *testing.T) {
 	tmp := deliveredIDsTestPath(t)
 
 	var markedReadCalls int
@@ -1305,6 +1526,15 @@ func TestResolveChatWakeRetriesMarkReadAndCachesDeliveredIDs(t *testing.T) {
 	if first.Skip {
 		t.Fatalf("first delivery unexpectedly skipped: %+v", first)
 	}
+	if markedReadCalls != 0 {
+		t.Fatalf("chat was marked read before provider delivery: calls=%d", markedReadCalls)
+	}
+	if first.AfterDelivery == nil {
+		t.Fatal("expected post-delivery acknowledgement")
+	}
+	if err := first.AfterDelivery(context.Background()); err == nil {
+		t.Fatal("expected mark-read failure")
+	}
 	if markedReadCalls != 2 {
 		t.Fatalf("mark_read_calls=%d, want 2", markedReadCalls)
 	}
@@ -1313,8 +1543,8 @@ func TestResolveChatWakeRetriesMarkReadAndCachesDeliveredIDs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := delivered["dedup-msg-1"]; !ok {
-		t.Fatalf("missing delivered id dedup-msg-1: %#v", delivered)
+	if _, ok := delivered["dedup-msg-1"]; ok {
+		t.Fatalf("failed upstream ack must not suppress message locally: %#v", delivered)
 	}
 
 	second, err := resolveChatWake(context.Background(), client, awid.AgentEvent{
@@ -1327,7 +1557,7 @@ func TestResolveChatWakeRetriesMarkReadAndCachesDeliveredIDs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !second.Skip {
-		t.Fatalf("expected duplicate wake to be skipped, got %+v", second)
+	if second.Skip {
+		t.Fatalf("failed acknowledgement made the message non-retryable: %+v", second)
 	}
 }

--- a/cli/go/cmd/aw/run_dispatch_test.go
+++ b/cli/go/cmd/aw/run_dispatch_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -650,7 +651,7 @@ func TestResolveChatWakeBoundsBatchAndLeavesRemainderRetryable(t *testing.T) {
 		t.Fatalf("maxChatMessagesPerWake=%d, want reviewed bound %d", maxChatMessagesPerWake, expectedBatchLimit)
 	}
 	deliveredDir := deliveredIDsTestPath(t)
-	messages := make([]awid.ChatMessage, expectedBatchLimit+2)
+	messages := make([]awid.ChatMessage, 121)
 	for i := range messages {
 		messages[i] = awid.ChatMessage{
 			MessageID: fmt.Sprintf("batch-%02d", i),
@@ -663,7 +664,17 @@ func TestResolveChatWakeBoundsBatchAndLeavesRemainderRetryable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s1/messages"):
-			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: messages[acked+1:]})
+			unread := messages[acked+1:]
+			limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+			if err != nil || limit < 1 {
+				t.Fatalf("invalid history limit %q", r.URL.Query().Get("limit"))
+			}
+			// Production selects newest LIMIT rows, then returns that suffix in
+			// chronological order.
+			if len(unread) > limit {
+				unread = unread[len(unread)-limit:]
+			}
+			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: unread})
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
 			var req awid.ChatMarkReadRequest
 			json.NewDecoder(r.Body).Decode(&req)
@@ -696,10 +707,8 @@ func TestResolveChatWakeBoundsBatchAndLeavesRemainderRetryable(t *testing.T) {
 			t.Fatalf("bounded context omitted index %d", i)
 		}
 	}
-	for i := expectedBatchLimit; i < len(messages); i++ {
-		if strings.Contains(first.CycleContext, messages[i].Body) {
-			t.Fatalf("bounded context included index %d", i)
-		}
+	if strings.Contains(first.CycleContext, messages[expectedBatchLimit].Body) {
+		t.Fatalf("bounded context included index %d", expectedBatchLimit)
 	}
 	if first.AfterDelivery == nil {
 		t.Fatal("expected bounded batch acknowledgement")
@@ -728,10 +737,135 @@ func TestResolveChatWakeBoundsBatchAndLeavesRemainderRetryable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := expectedBatchLimit; i < len(messages); i++ {
+	for i := expectedBatchLimit; i < expectedBatchLimit*2; i++ {
 		if !strings.Contains(second.CycleContext, messages[i].Body) {
-			t.Fatalf("remainder context omitted index %d: %q", i, second.CycleContext)
+			t.Fatalf("next batch omitted index %d: %q", i, second.CycleContext)
 		}
+	}
+	if strings.Contains(second.CycleContext, messages[expectedBatchLimit*2].Body) {
+		t.Fatalf("next batch exceeded reviewed bound: %q", second.CycleContext)
+	}
+}
+
+func TestResolveChatWakePendingDoesNotAckOmittedOlderPrefix(t *testing.T) {
+	const expectedBatchLimit = 20
+	deliveredIDsTestPath(t)
+	messages := make([]awid.ChatMessage, 121)
+	for i := range messages {
+		messages[i] = awid.ChatMessage{
+			MessageID: fmt.Sprintf("pending-%03d", i),
+			FromAgent: "alice",
+			Body:      fmt.Sprintf("pending-request-%03d", i),
+		}
+	}
+	markedReadUpTo := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/chat/pending":
+			json.NewEncoder(w).Encode(awid.ChatPendingResponse{Pending: []awid.ChatPendingItem{{
+				SessionID: "s1", LastFrom: "alice", LastMessage: messages[len(messages)-1].Body,
+				UnreadCount: len(messages), SenderWaiting: true,
+			}}})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s1/messages"):
+			limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+			if err != nil || limit < 1 {
+				t.Fatalf("invalid history limit %q", r.URL.Query().Get("limit"))
+			}
+			selected := messages
+			if len(selected) > limit {
+				selected = selected[len(selected)-limit:]
+			}
+			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: selected})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
+			var req awid.ChatMarkReadRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			markedReadUpTo = req.UpToMessageID
+			json.NewEncoder(w).Encode(awid.ChatMarkReadResponse{Success: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := mustWebClient(t, server.URL)
+	resolved, err := resolveChatWake(context.Background(), client, awid.AgentEvent{
+		Type:      awid.AgentEventActionableChat,
+		SessionID: "s1",
+		FromAlias: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < expectedBatchLimit; i++ {
+		if !strings.Contains(resolved.CycleContext, messages[i].Body) {
+			t.Fatalf("pending context omitted oldest index %d: %q", i, resolved.CycleContext)
+		}
+	}
+	if strings.Contains(resolved.CycleContext, messages[expectedBatchLimit].Body) {
+		t.Fatalf("pending context exceeded reviewed bound: %q", resolved.CycleContext)
+	}
+	if resolved.AfterDelivery == nil {
+		t.Fatal("expected pending batch acknowledgement")
+	}
+	if err := resolved.AfterDelivery(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if markedReadUpTo != messages[expectedBatchLimit-1].MessageID {
+		t.Fatalf("marked through %q, want %q", markedReadUpTo, messages[expectedBatchLimit-1].MessageID)
+	}
+}
+
+func TestResolveChatWakeIncompleteHistoryNeverCreatesAcknowledgement(t *testing.T) {
+	deliveredIDsTestPath(t)
+	var readCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/chat/pending":
+			json.NewEncoder(w).Encode(awid.ChatPendingResponse{Pending: []awid.ChatPendingItem{{
+				SessionID: "s1", LastFrom: "alice", LastMessage: "newest summary",
+				UnreadCount: 121, SenderWaiting: true,
+			}}})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s1/messages"):
+			messages := make([]awid.ChatMessage, 100)
+			for i := range messages {
+				messages[i] = awid.ChatMessage{MessageID: fmt.Sprintf("suffix-%03d", i+21), FromAgent: "alice", Body: "suffix"}
+			}
+			json.NewEncoder(w).Encode(awid.ChatHistoryResponse{Messages: messages})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/read"):
+			readCalls++
+			json.NewEncoder(w).Encode(awid.ChatMarkReadResponse{Success: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := mustWebClient(t, server.URL)
+	resolved, err := resolveChatWake(context.Background(), client, awid.AgentEvent{
+		Type:        awid.AgentEventActionableChat,
+		SessionID:   "s1",
+		MessageID:   "suffix-120",
+		FromAlias:   "alice",
+		UnreadCount: 121,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Skip || !strings.Contains(resolved.CycleContext, "newest summary") {
+		t.Fatalf("expected unacknowledged pending summary fallback, got %+v", resolved)
+	}
+	if resolved.AfterDelivery != nil {
+		t.Fatal("incomplete history created a watermark acknowledgement")
+	}
+	if readCalls != 0 {
+		t.Fatalf("incomplete history marked %d times", readCalls)
+	}
+}
+
+func TestUnreadChatHistoryLimitRejectsUnpageableBacklog(t *testing.T) {
+	if _, err := unreadChatHistoryLimit(maxChatHistoryFetch + 1); err == nil {
+		t.Fatal("backlog beyond fetch limit must fail rather than watermark an omitted prefix")
 	}
 }
 

--- a/cli/go/cmd/aw/run_test.go
+++ b/cli/go/cmd/aw/run_test.go
@@ -17,6 +17,7 @@ import (
 	aweb "github.com/awebai/aw"
 	"github.com/awebai/aw/awconfig"
 	"github.com/awebai/aw/awid"
+	"github.com/awebai/aw/chat"
 	awrun "github.com/awebai/aw/run"
 	"github.com/spf13/cobra"
 )
@@ -724,7 +725,7 @@ func TestNewRunDispatcherBuildsIdleActionableChatPrompt(t *testing.T) {
 	}
 }
 
-func TestResolveChatWakeUsesExactUnreadMessageIDBeforePendingLastMessage(t *testing.T) {
+func TestResolveChatWakePresentsEveryUnreadMessageInTheBatch(t *testing.T) {
 	_ = deliveredIDsTestPath(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -758,8 +759,8 @@ func TestResolveChatWakeUsesExactUnreadMessageIDBeforePendingLastMessage(t *test
 	if !strings.Contains(resolved.CycleContext, "please review the retry path") {
 		t.Fatalf("expected exact unread message body, got %q", resolved.CycleContext)
 	}
-	if strings.Contains(resolved.CycleContext, "newer follow-up") {
-		t.Fatalf("expected resolver not to collapse to pending last_message, got %q", resolved.CycleContext)
+	if !strings.Contains(resolved.CycleContext, "newer follow-up") {
+		t.Fatalf("expected all unread messages in provider context, got %q", resolved.CycleContext)
 	}
 }
 
@@ -1076,6 +1077,157 @@ func TestRunUsesWakeEventToTriggerSecondCycle(t *testing.T) {
 	}
 	if !builds[1].ContinueSession || builds[1].SessionID != "sess-42" {
 		t.Fatalf("second run should continue session sess-42, got %+v", builds[1])
+	}
+}
+
+func TestNativeRunChatProviderFailureLeavesBatchForRestart(t *testing.T) {
+	initRunCommandVars()
+	deliveredDir := deliveredIDsTestPath(t)
+
+	oldLoad := runLoadUserConfig
+	oldResolveSettings := runResolveSettings
+	oldNewProvider := runNewProvider
+	oldResolveClient := runResolveClientForDir
+	oldNewLoop := runNewLoop
+	oldNewScreen := runNewScreenController
+	oldWorkspaceState := runWorkspaceStateForDir
+	t.Cleanup(func() {
+		runLoadUserConfig = oldLoad
+		runResolveSettings = oldResolveSettings
+		runNewProvider = oldNewProvider
+		runResolveClientForDir = oldResolveClient
+		runNewLoop = oldNewLoop
+		runNewScreenController = oldNewScreen
+		runWorkspaceStateForDir = oldWorkspaceState
+		initRunCommandVars()
+	})
+
+	var stateMu sync.Mutex
+	markedRead := false
+	markReadCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/events/stream"):
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("response writer does not support flushing")
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, "event: connected\ndata: {\"agent_id\":\"a-1\",\"team_id\":\"backend:acme.com\"}\n\n")
+			flusher.Flush()
+			_, _ = io.WriteString(w, "event: actionable_chat\ndata: {\"message_id\":\"restart-2\",\"from_alias\":\"mia\",\"session_id\":\"s-restart\",\"wake_mode\":\"interrupt\",\"unread_count\":2,\"sender_waiting\":true}\n\n")
+			flusher.Flush()
+			<-r.Context().Done()
+		case strings.HasPrefix(r.URL.Path, "/v1/chat/sessions/s-restart/messages"):
+			stateMu.Lock()
+			read := markedRead
+			stateMu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if read {
+				_, _ = io.WriteString(w, `{"messages":[]}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"messages":[{"message_id":"restart-1","from_agent":"mia","body":"first survives","timestamp":"2026-03-25T00:00:00Z"},{"message_id":"restart-2","from_agent":"mia","body":"second survives","timestamp":"2026-03-25T00:01:00Z"}]}`)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/read"):
+			stateMu.Lock()
+			markedRead = true
+			markReadCalls++
+			stateMu.Unlock()
+			_, _ = io.WriteString(w, `{"success":true,"messages_marked":2}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := aweb.New(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runLoadUserConfig = func(string) (awrun.UserConfig, error) { return awrun.UserConfig{}, nil }
+	runResolveSettings = func(awrun.UserConfig, awrun.SettingOverrides) (awrun.Settings, error) {
+		return awrun.Settings{BasePrompt: "persistent mission", WaitSeconds: 30, IdleWaitSeconds: 1}, nil
+	}
+	runResolveClientForDir = func(string) (*aweb.Client, *awconfig.Selection, error) {
+		return client, &awconfig.Selection{Domain: "team", Alias: "rose"}, nil
+	}
+	runWorkspaceStateForDir = func(string) (runWorkspaceState, error) { return runWorkspaceStateInitialized, nil }
+	runNewScreenController = func(io.Reader, io.Writer) *awrun.ScreenController { return nil }
+
+	lastRunnerCalls := 0
+	lastRunnerPrompt := ""
+	runNative := func(failWake bool) ([]string, error) {
+		provider := &recordingRunProvider{}
+		runNewProvider = func(string) (awrun.Provider, error) { return provider, nil }
+		runNewLoop = func(provider awrun.Provider, out io.Writer) *awrun.Loop {
+			loop := awrun.NewLoop(provider, out)
+			recording := provider.(*recordingRunProvider)
+			loop.Runner = func(ctx context.Context, dir string, argv []string, onLine func(string), stderrSink any) error {
+				lastRunnerCalls++
+				prompts, _ := recording.snapshot()
+				if len(prompts) > 0 {
+					lastRunnerPrompt = prompts[len(prompts)-1]
+				}
+				if failWake && strings.Contains(lastRunnerPrompt, "first survives") {
+					return errors.New("provider failed before accepting chat")
+				}
+				onLine("done")
+				return nil
+			}
+			return loop
+		}
+
+		cmd := &cobraCommandClone{Command: *runCmd}
+		cmd.ResetFlagsForTest()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd.Command.SetContext(ctx)
+		runMaxRuns = 2
+		var stdout, stderr bytes.Buffer
+		setRunCommandIO(&cmd.Command, strings.NewReader(""), &stdout, &stderr)
+		err := runRun(&cmd.Command, []string{"claude"})
+		prompts, _ := provider.snapshot()
+		return prompts, err
+	}
+
+	firstPrompts, err := runNative(true)
+	if err == nil || !strings.Contains(err.Error(), "provider failed before accepting chat") {
+		t.Fatalf("first run error=%v prompts=%#v runner_calls=%d last_runner_prompt=%q", err, firstPrompts, lastRunnerCalls, lastRunnerPrompt)
+	}
+	stateMu.Lock()
+	firstMarked, firstCalls := markedRead, markReadCalls
+	stateMu.Unlock()
+	if firstMarked || firstCalls != 0 {
+		t.Fatalf("failed provider suppressed chat: marked=%v calls=%d", firstMarked, firstCalls)
+	}
+	if delivered, err := chat.LoadDeliveredIDsForDir(deliveredDir); err != nil {
+		t.Fatal(err)
+	} else if len(delivered) != 0 {
+		t.Fatalf("failed provider persisted delivered IDs: %#v", delivered)
+	}
+
+	prompts, err := runNative(false)
+	if err != nil {
+		t.Fatalf("restart run: %v", err)
+	}
+	if len(prompts) != 2 || !strings.Contains(prompts[1], "first survives") || !strings.Contains(prompts[1], "second survives") {
+		t.Fatalf("restart did not present pending batch: %#v", prompts)
+	}
+	stateMu.Lock()
+	finalMarked, finalCalls := markedRead, markReadCalls
+	stateMu.Unlock()
+	if !finalMarked || finalCalls != 1 {
+		t.Fatalf("successful restart acknowledgement: marked=%v calls=%d", finalMarked, finalCalls)
+	}
+	delivered, err := chat.LoadDeliveredIDsForDir(deliveredDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"restart-1", "restart-2"} {
+		if _, ok := delivered[id]; !ok {
+			t.Fatalf("restart did not persist %s: %#v", id, delivered)
+		}
 	}
 }
 

--- a/cli/go/run/loop.go
+++ b/cli/go/run/loop.go
@@ -241,15 +241,17 @@ func (l *Loop) Run(ctx context.Context, opts LoopOptions) error {
 			return fmt.Errorf("prompt cannot be empty")
 		}
 		state.Run++
-		if err := l.runOnce(ctx, opts, state, fullPrompt, decision.ImagePaths, displayLines, decision.UserPrompt); err != nil {
-			if state.StopRequested && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		runErr := l.runOnce(ctx, opts, state, fullPrompt, decision.ImagePaths, displayLines, decision.UserPrompt)
+		interrupted := errors.Is(runErr, errRunInterrupted)
+		if runErr != nil && !interrupted {
+			if state.StopRequested && (errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded)) {
 				return nil
 			}
-			return err
+			return runErr
 		}
-		if decision.AfterDelivery != nil {
+		if !interrupted && decision.AfterDelivery != nil {
 			if err := decision.AfterDelivery(ctx); err != nil {
-				l.printf("info: post-delivery finalization failed: %v\n", err)
+				return fmt.Errorf("post-delivery finalization failed: %w", err)
 			}
 		}
 		if state.ExitConfirmPending {
@@ -319,6 +321,8 @@ func (l *Loop) nextPrompt(ctx context.Context, opts LoopOptions, st *state) (Dis
 	}
 	return DispatchDecision{Mission: explicitMissionPrompt, WaitSeconds: opts.WaitSeconds}, nil
 }
+
+var errRunInterrupted = errors.New("provider run interrupted")
 
 func (l *Loop) runOnce(ctx context.Context, opts LoopOptions, st *state, prompt string, imagePaths []string, displayLines []DisplayLine, userPrompt string) error {
 	l.clearStatusLine()
@@ -464,7 +468,7 @@ func (l *Loop) runOnce(ctx context.Context, opts LoopOptions, st *state, prompt 
 				st.Paused = true
 				st.PauseAfterRun = true
 				st.RunInterrupted = false
-				return nil
+				return errRunInterrupted
 			}
 			st.RunInterrupted = false
 			if strings.TrimSpace(st.LastRunError) != "" {

--- a/cli/go/run/loop.go
+++ b/cli/go/run/loop.go
@@ -249,7 +249,7 @@ func (l *Loop) Run(ctx context.Context, opts LoopOptions) error {
 		}
 		if decision.AfterDelivery != nil {
 			if err := decision.AfterDelivery(ctx); err != nil {
-				l.printf("info: post-delivery acknowledgement failed; source remains pending: %v\n", err)
+				l.printf("info: post-delivery finalization failed: %v\n", err)
 			}
 		}
 		if state.ExitConfirmPending {
@@ -470,6 +470,9 @@ func (l *Loop) runOnce(ctx context.Context, opts LoopOptions, st *state, prompt 
 			if strings.TrimSpace(st.LastRunError) != "" {
 				return errors.New(st.LastRunError)
 			}
+			if err != nil {
+				return err
+			}
 			if followUpRun {
 				switch {
 				case strings.TrimSpace(observedSessionID) == "":
@@ -488,7 +491,7 @@ func (l *Loop) runOnce(ctx context.Context, opts LoopOptions, st *state, prompt 
 					return nil
 				}
 			}
-			return err
+			return nil
 		case event := <-l.controlEvents():
 			l.applyControlEvent(event, st, true, cancel)
 		case busEvt := <-busInterrupts:

--- a/cli/go/run/loop_test.go
+++ b/cli/go/run/loop_test.go
@@ -384,6 +384,56 @@ func TestLoopLeavesWakePendingWhenProviderDeliveryFails(t *testing.T) {
 	}
 }
 
+func TestLoopInterruptedProviderDoesNotFinalizeDelivery(t *testing.T) {
+	loop := NewLoop(fakeProvider{event: &Event{Type: EventDone}}, &bytes.Buffer{})
+	controller := newFakeInputController()
+	loop.Control = controller
+	started := make(chan struct{})
+	loop.Runner = func(ctx context.Context, _ string, _ []string, _ func(string), _ any) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	finalized := false
+	loop.Dispatch = &fakeDispatcher{decisions: []DispatchDecision{{
+		Mission: "incoming chat",
+		AfterDelivery: func(context.Context) error {
+			finalized = true
+			return nil
+		},
+	}}}
+	go func() {
+		<-started
+		controller.events <- ControlEvent{Type: ControlStop}
+	}()
+
+	if err := loop.Run(context.Background(), LoopOptions{MaxRuns: 1}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if finalized {
+		t.Fatal("interrupted provider run finalized an unpresented wake")
+	}
+}
+
+func TestLoopPropagatesPostDeliveryFailure(t *testing.T) {
+	loop := NewLoop(fakeProvider{event: &Event{Type: EventDone}}, &bytes.Buffer{})
+	loop.Runner = func(_ context.Context, _ string, _ []string, onLine func(string), _ any) error {
+		onLine("ignored")
+		return nil
+	}
+	loop.Dispatch = &fakeDispatcher{decisions: []DispatchDecision{{
+		Mission: "incoming chat",
+		AfterDelivery: func(context.Context) error {
+			return errors.New("mark read failed")
+		},
+	}}}
+
+	err := loop.Run(context.Background(), LoopOptions{MaxRuns: 1})
+	if err == nil || !strings.Contains(err.Error(), "mark read failed") {
+		t.Fatalf("Run error=%v, want post-delivery failure", err)
+	}
+}
+
 func TestLoopExposesProviderInputWithPTY(t *testing.T) {
 	loop := NewLoop(fakeProvider{event: &Event{Type: EventDone}}, &bytes.Buffer{})
 	var sawStdinReady bool


### PR DESCRIPTION
## Summary
- present bounded chat batches instead of showing one message while suppressing the whole unread history
- defer server read acknowledgement and local delivered-ID persistence until provider success
- acknowledge the server before local persistence so failed upstream acknowledgement leaves the batch retryable
- propagate both acknowledgement and persistence failures
- surface follow-up provider process failures before session-continuity fallback can hide them

## Safety properties
- at most 20 incoming messages are presented per wake; the remainder stay unread for the next wake
- self-authored and previously delivered entries are not included or newly persisted
- provider failure changes neither server read state nor local delivered-ID state
- a server acknowledgement failure cannot write local suppression state
- local persistence starts only after upstream acknowledgement succeeds

## Tests
- full Go suite
- full Go race suite
- freshness gate
- native aw run integration: provider failure leaves a two-message batch pending, restart presents both and acknowledges once
- bounded batch/remainder, mixed self/incoming, upstream failure retry, local persistence failure, and deferred acknowledgement tests
- isolated mutations proved the tests fail for local-first ordering, widening/removing the batch bound, and hiding follow-up provider errors

Already-lost messages from the historical four-month defect window are not recovered. Native aw run is kept correct without redesigning its wake loop. No release, tag, publish, deployment, identity, or auth changes are included.
