### PR TITLE
fix(run): serialize provider output with loop state

### DIFF
--- a/.github/go-vulnerability-exceptions.json
+++ b/.github/go-vulnerability-exceptions.json
@@ -4,7 +4,7 @@
     {
       "id": "GO-2026-5320",
       "owner": "aw-coordinator",
-      "rationale": "The reported class is XSS in goldmark HTML generation. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter.",
+      "rationale": "The reported class is XSS in goldmark HTML generation. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter. Reachability re-reviewed for default-aaky on 2026-07-25: single-owner rendering moved handleOutputLine from the provider Runner callback into main-loop runOnce; the ANSI-terminal sink and accepted-risk justification are unchanged.",
       "review_on": "2027-01-25",
       "affected_module": "github.com/yuin/goldmark",
       "allowed_project_traces": [
@@ -23,15 +23,11 @@
           },
           {
             "package": "github.com/awebai/aw/run",
-            "function": "runOnce$7$1"
+            "function": "runOnce"
           },
           {
             "package": "github.com/awebai/aw/run",
-            "function": "scanCommandPipe"
-          },
-          {
-            "package": "github.com/awebai/aw/run",
-            "function": "RealCommandRunner"
+            "function": "Run"
           }
         ]
       ]
@@ -39,7 +35,7 @@
     {
       "id": "GO-2025-3595",
       "owner": "aw-coordinator",
-      "rationale": "The reported class is unsafe web-page generation in x/net/html. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter.",
+      "rationale": "The reported class is unsafe web-page generation in x/net/html. The only reachable path is run/markdown.go through glamour, whose sink is an ANSI terminal rather than a browser or HTML interpreter. Reachability re-reviewed for default-aaky on 2026-07-25: single-owner rendering moved handleOutputLine from the provider Runner callback into main-loop runOnce; the ANSI-terminal sink and accepted-risk justification are unchanged.",
       "review_on": "2027-01-25",
       "affected_module": "golang.org/x/net",
       "allowed_project_traces": [
@@ -58,15 +54,11 @@
           },
           {
             "package": "github.com/awebai/aw/run",
-            "function": "runOnce$7$1"
+            "function": "runOnce"
           },
           {
             "package": "github.com/awebai/aw/run",
-            "function": "scanCommandPipe"
-          },
-          {
-            "package": "github.com/awebai/aw/run",
-            "function": "RealCommandRunner"
+            "function": "Run"
           }
         ]
       ]

--- a/cli/go/run/loop.go
+++ b/cli/go/run/loop.go
@@ -421,6 +421,18 @@ func (l *Loop) runOnce(ctx context.Context, opts LoopOptions, st *state, prompt 
 	defer cancel()
 
 	errCh := make(chan error, 1)
+	type providerOutput struct {
+		line  bool
+		label string
+		text  string
+	}
+	providerOutputCh := make(chan providerOutput)
+	sendProviderOutput := func(output providerOutput) {
+		select {
+		case providerOutputCh <- output:
+		case <-runCtx.Done():
+		}
+	}
 
 	var busInterrupts <-chan BusEvent
 	if l.EventBus != nil {
@@ -438,28 +450,34 @@ func (l *Loop) runOnce(ctx context.Context, opts LoopOptions, st *state, prompt 
 			providerInput.SetWriter(w)
 		}
 		sinks.ptyPartial = func(chunk string) {
-			l.handleRawProviderChunk("provider", chunk, presenter)
+			sendProviderOutput(providerOutput{label: "provider", text: chunk})
 		}
 	} else {
 		sinks.stderrLine = func(line string) {
-			l.handleRawProviderChunk("provider stderr", line+"\n", presenter)
+			sendProviderOutput(providerOutput{label: "provider stderr", text: line + "\n"})
 		}
 		sinks.stderrPartial = func(chunk string) {
-			l.handleRawProviderChunk("provider stderr", chunk, presenter)
+			sendProviderOutput(providerOutput{label: "provider stderr", text: chunk})
 		}
 		sinks.stdoutPartial = func(chunk string) {
-			l.handleRawProviderChunk("provider stdout", chunk, presenter)
+			sendProviderOutput(providerOutput{label: "provider stdout", text: chunk})
 		}
 	}
 
 	go func() {
 		errCh <- l.Runner(runCtx, opts.WorkingDir, argv, func(line string) {
-			l.handleOutputLine(line, presenter, st, &observedSessionID, &agentText)
+			sendProviderOutput(providerOutput{line: true, text: line})
 		}, sinks)
 	}()
 
 	for {
 		select {
+		case output := <-providerOutputCh:
+			if output.line {
+				l.handleOutputLine(output.text, presenter, st, &observedSessionID, &agentText)
+			} else {
+				l.handleRawProviderChunk(output.label, output.text, presenter)
+			}
 		case err := <-errCh:
 			st.RunPhase = RunPhaseIdle
 			l.drainPendingControlEvents(st, true)
@@ -1777,11 +1795,10 @@ func (l *Loop) markStatusDirty() {
 // single load yields a consistent snapshot; do not add a second atomic, because
 // two atomics give two consistent reads and one inconsistent LINE.
 //
-// This says nothing about the rendering path as a whole, which is NOT
-// single-owner: handleOutputLine renders from the provider output goroutine
-// while also mutating the shared state the formatters read. That ownership
-// violation is tracked as default-aaky; do not read the paragraph above as
-// evidence that rendering is otherwise safe.
+// The rendering path is single-owner: provider callbacks send immutable output
+// events to runOnce, and the main loop parses them, mutates state, and renders.
+// Background goroutines must signal or send values; they must never read the
+// main-loop state or call a status formatter directly.
 func (l *Loop) connState() ConnectionState {
 	if l.EventBus == nil {
 		return ConnDisconnected

--- a/cli/go/run/status_ownership_test.go
+++ b/cli/go/run/status_ownership_test.go
@@ -3,6 +3,8 @@ package run
 import (
 	"bytes"
 	"context"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,6 +145,66 @@ func drainStatusDirty(l *Loop) {
 // state.ConnState and called refreshStatusLine directly — which also WRITES
 // st.RunPhase — so these two goroutines wrote the same loop state concurrently
 // and the detector fired. Now the bus only signals and the main loop renders.
+func TestProviderOutputAndControlRenderingHaveSingleOwner(t *testing.T) {
+	const iterations = 2000
+
+	cost := 0.01
+	ui := newRecordingUI()
+	started := make(chan struct{})
+	controlsQueued := make(chan struct{})
+	loop := NewLoop(&fakeProvider{event: &Event{Type: EventDone, CostUSD: &cost}}, io.Discard)
+	loop.Control = ui
+	emitted := 0
+	loop.Runner = func(_ context.Context, _ string, _ []string, onLine func(string), _ any) error {
+		close(started)
+		for range iterations {
+			onLine("cost")
+			emitted++
+		}
+		<-controlsQueued
+		return nil
+	}
+
+	go func() {
+		<-started
+		defer close(controlsQueued)
+		for i := range iterations {
+			eventType := ControlAutofeedOff
+			if i%2 == 0 {
+				eventType = ControlAutofeedOn
+			}
+			ui.events <- ControlEvent{Type: eventType}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if err := loop.Run(ctx, LoopOptions{InitialPrompt: "exercise concurrent ownership", MaxRuns: 1}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if emitted != iterations {
+		t.Fatalf("provider output path emitted %d lines, want %d", emitted, iterations)
+	}
+	ui.statusMu.Lock()
+	defer ui.statusMu.Unlock()
+	controlRenders := 0
+	finalCostRendered := false
+	for _, status := range ui.statuses {
+		if status == "autofeed on" || status == "autofeed off" {
+			controlRenders++
+		}
+		if strings.Contains(status, "$20.00") {
+			finalCostRendered = true
+		}
+	}
+	if controlRenders != iterations {
+		t.Fatalf("main-loop control path rendered %d updates, want %d", controlRenders, iterations)
+	}
+	if !finalCostRendered {
+		t.Fatal("provider output path did not render the final cumulative cost")
+	}
+}
+
 func TestFlappingEventBusDoesNotRaceStatusLineRendering(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes default-aaky. Provider runner callbacks now send parsed lines and raw chunks to runOnce over one unbuffered channel; the main loop alone parses, mutates session/usage state, and renders. A constructed control/output concurrency test reproduces the live race under -race when production wiring is reverted.