### PR TITLE
fix(server): separate attested and received message time

### DIFF
--- a/server/src/aweb/federation/envelope.py
+++ b/server/src/aweb/federation/envelope.py
@@ -142,7 +142,12 @@ def verify_federation_envelope(
         if isinstance(envelope, FederationEnvelope)
         else FederationEnvelope.model_validate(envelope)
     )
-    _enforce_timestamp_skew(model.timestamp, now=now, max_skew_seconds=max_skew_seconds)
+    enforce_message_timestamp_skew(
+        _parse_timestamp(model.timestamp),
+        now=now,
+        max_skew_seconds=max_skew_seconds,
+        label="Federation envelope timestamp",
+    )
     _enforce_expected_fields(model, expected or {})
     if _is_encrypted_v2(model):
         _enforce_encrypted_payload_binding(model, signature, now=now)
@@ -181,11 +186,16 @@ def _parse_timestamp(value: str) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
-def _enforce_timestamp_skew(value: str, *, now: datetime | None, max_skew_seconds: int) -> None:
+def enforce_message_timestamp_skew(
+    timestamp: datetime,
+    *,
+    now: datetime | None = None,
+    max_skew_seconds: int = FEDERATION_TIMESTAMP_SKEW_SECONDS,
+    label: str = "timestamp",
+) -> None:
     current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
-    timestamp = _parse_timestamp(value)
     if abs((current - timestamp).total_seconds()) > max_skew_seconds:
-        raise FederationEnvelopeError("Federation envelope timestamp outside accepted skew")
+        raise FederationEnvelopeError(f"{label} outside accepted skew")
 
 
 def _enforce_expected_fields(model: FederationEnvelope, expected: Mapping[str, Any | None]) -> None:

--- a/server/src/aweb/mcp/tools/chat.py
+++ b/server/src/aweb/mcp/tools/chat.py
@@ -500,7 +500,9 @@ async def chat_send(
         except ServiceError as exc:
             return json.dumps({"error": exc.detail})
 
-        msg_created_at = datetime.now(timezone.utc).replace(microsecond=0)
+        # sender_attested_at is signed sender intent; send_in_session assigns
+        # independent server receipt time for ordering, so they may disagree.
+        sender_attested_at = datetime.now(timezone.utc).replace(microsecond=0)
         pre_message_id = uuid_mod.uuid4()
         to_value, to_current_did, to_stable_id = _recipient_signed_fields([target])
         from_value = (
@@ -515,7 +517,7 @@ async def chat_send(
             "from_did": (auth.did_key or "").strip(),
             "message_id": str(pre_message_id),
             "subject": "",
-            "timestamp": _signed_timestamp(msg_created_at),
+            "timestamp": _signed_timestamp(sender_attested_at),
             "to": to_value,
             "to_did": to_current_did,
             "type": "chat",
@@ -579,7 +581,7 @@ async def chat_send(
                     leaving=leaving,
                     hang_on=True,
                     message_id=str(pre_message_id),
-                    timestamp=_signed_timestamp(msg_created_at),
+                    timestamp=_signed_timestamp(sender_attested_at),
                     from_did=signed.from_did if signed else actor_did,
                     signature=signed.signature if signed else None,
                     signed_payload=signed.signed_payload if signed else None,
@@ -595,7 +597,7 @@ async def chat_send(
                     leaving=leaving,
                     wait_seconds=wait_seconds if wait else None,
                     message_id=str(pre_message_id),
-                    timestamp=_signed_timestamp(msg_created_at),
+                    timestamp=_signed_timestamp(sender_attested_at),
                     from_did=signed.from_did if signed else actor_did,
                     signature=signed.signature if signed else None,
                     signed_payload=signed.signed_payload if signed else None,
@@ -636,7 +638,6 @@ async def chat_send(
             message_version=message_version,
             encrypted_envelope=encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=msg_created_at,
             message_id=pre_message_id,
         )
         if msg is None:
@@ -667,7 +668,9 @@ async def chat_send(
         except ServiceError as exc:
             return json.dumps({"error": exc.detail})
 
-        msg_created_at = datetime.now(timezone.utc).replace(microsecond=0)
+        # sender_attested_at is signed sender intent; send_in_session assigns
+        # independent server receipt time for ordering, so they may disagree.
+        sender_attested_at = datetime.now(timezone.utc).replace(microsecond=0)
         pre_message_id = uuid_mod.uuid4()
         recipient_rows = await _session_recipient_rows(db_infra, session_id=sid, actor_dids=actor_dids)
         remote_recipients = [row for row in recipient_rows if row.get("delivery_origin")]
@@ -705,7 +708,7 @@ async def chat_send(
             "from_did": (auth.did_key or "").strip(),
             "message_id": str(pre_message_id),
             "subject": "",
-            "timestamp": _signed_timestamp(msg_created_at),
+            "timestamp": _signed_timestamp(sender_attested_at),
             "to": to_value,
             "to_did": to_current_did,
             "type": "chat",
@@ -760,7 +763,7 @@ async def chat_send(
                 hang_on=hang_on,
                 wait_seconds=wait_seconds if wait else None,
                 message_id=str(pre_message_id),
-                timestamp=_signed_timestamp(msg_created_at),
+                timestamp=_signed_timestamp(sender_attested_at),
                 from_did=signed.from_did if signed else session_actor_did,
                 signature=signed.signature if signed else None,
                 signed_payload=signed.signed_payload if signed else None,
@@ -802,7 +805,6 @@ async def chat_send(
             message_version=message_version,
             encrypted_envelope=encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=msg_created_at,
             message_id=pre_message_id,
         )
         if msg is None:

--- a/server/src/aweb/mcp/tools/mail.py
+++ b/server/src/aweb/mcp/tools/mail.py
@@ -181,7 +181,9 @@ async def send_mail(
 
     if conversation_ref:
         message_id = uuid_mod.uuid4()
-        created_at = datetime.now(timezone.utc).replace(microsecond=0)
+        # sender_attested_at is signed sender intent; deliver_message returns
+        # independent server receipt time for ordering, so they may disagree.
+        sender_attested_at = datetime.now(timezone.utc).replace(microsecond=0)
         sender_did = primary_auth_did(auth)
         signature: str | None = None
         signed_payload: str | None = None
@@ -222,7 +224,7 @@ async def send_mail(
             "from_did": (auth.did_key or "").strip(),
             "message_id": str(message_id),
             "subject": subject,
-            "timestamp": _utc_iso(created_at),
+            "timestamp": _utc_iso(sender_attested_at),
             "to": signed_to,
             "to_did": signed_to_did,
             "type": "mail",
@@ -280,7 +282,7 @@ async def send_mail(
                     encrypted_envelope=encrypted.encrypted_envelope if encrypted is not None else None,
                     priority=cast(MessagePriority, priority),
                     message_id=str(message_id),
-                    timestamp=_utc_iso(created_at),
+                    timestamp=_utc_iso(sender_attested_at),
                     from_did=sender_did,
                     signature=None if encrypted is not None else signature,
                     signed_payload=None if encrypted is not None else signed_payload,
@@ -300,7 +302,6 @@ async def send_mail(
                     recipient_did=recipient_did,
                     to_agent_id=None,
                     to_alias=recipient_participant.get("alias"),
-                    created_at=created_at,
                     msg_uuid=message_id,
                 )
                 return json.dumps(
@@ -312,7 +313,7 @@ async def send_mail(
                         "to": recipient_participant.get("alias") or recipient_did,
                     }
                 )
-            message_id, created_at = await deliver_message(
+            message_id, server_received_at = await deliver_message(
                 db_infra,
                 registry_client=registry_client,
                 recipient_agent=recipient,
@@ -333,7 +334,6 @@ async def send_mail(
                 message_version=encrypted.message_version if encrypted is not None else 1,
                 encrypted_envelope=encrypted.encrypted_envelope if encrypted is not None else None,
                 encrypted_metadata=encrypted_metadata,
-                created_at=created_at,
                 message_id=message_id,
                 conversation_id=conversation_ref,
                 skip_policy_check=True,
@@ -348,7 +348,7 @@ async def send_mail(
                 "message_id": str(message_id),
                 "conversation_id": conversation_ref,
                 "status": "delivered",
-                "delivered_at": _utc_iso(created_at),
+                "delivered_at": _utc_iso(server_received_at),
                 "to": recipient_participant.get("alias") or recipient_did,
             }
         )
@@ -412,7 +412,9 @@ async def send_mail(
 
     message_id = uuid_mod.uuid4()
     initial_conversation_id = uuid_mod.uuid4()
-    created_at = datetime.now(timezone.utc).replace(microsecond=0)
+    # sender_attested_at is signed sender intent; deliver_message returns
+    # independent server receipt time for ordering, so they may disagree.
+    sender_attested_at = datetime.now(timezone.utc).replace(microsecond=0)
     sender_did = primary_auth_did(auth)
     signature: str | None = None
     signed_payload: str | None = None
@@ -431,7 +433,7 @@ async def send_mail(
         "from_did": (auth.did_key or "").strip(),
         "message_id": str(message_id),
         "subject": subject,
-        "timestamp": _utc_iso(created_at),
+        "timestamp": _utc_iso(sender_attested_at),
         "to": signed_to,
         "to_did": to_current_did,
         "type": "mail",
@@ -495,7 +497,7 @@ async def send_mail(
                 encrypted_envelope=encrypted.encrypted_envelope if encrypted is not None else None,
                 priority=cast(MessagePriority, priority),
                 message_id=str(message_id),
-                timestamp=_utc_iso(created_at),
+                timestamp=_utc_iso(sender_attested_at),
                 from_did=sender_did,
                 signature=None if encrypted is not None else signature,
                 signed_payload=None if encrypted is not None else signed_payload,
@@ -515,7 +517,6 @@ async def send_mail(
                 recipient_did=recipient_did,
                 to_agent_id=None,
                 to_alias=recipient_alias,
-                created_at=created_at,
                 msg_uuid=message_id,
             )
             return json.dumps(
@@ -550,7 +551,7 @@ async def send_mail(
             ],
             team_id=auth.team_id,
         )
-        message_id, created_at = await deliver_message(
+        message_id, server_received_at = await deliver_message(
             db_infra,
             registry_client=registry_client,
             recipient_agent=recipient,
@@ -571,7 +572,6 @@ async def send_mail(
             message_version=encrypted.message_version if encrypted is not None else 1,
             encrypted_envelope=encrypted.encrypted_envelope if encrypted is not None else None,
             encrypted_metadata=encrypted_metadata,
-            created_at=created_at,
             message_id=message_id,
             conversation_id=conversation["conversation_id"],
             skip_policy_check=True,
@@ -585,7 +585,7 @@ async def send_mail(
             "message_id": str(message_id),
             "conversation_id": conversation["conversation_id"],
             "status": "delivered",
-            "delivered_at": _utc_iso(created_at),
+            "delivered_at": _utc_iso(server_received_at),
             "to": recipient_alias,
         }
     )

--- a/server/src/aweb/messaging/chat.py
+++ b/server/src/aweb/messaging/chat.py
@@ -377,7 +377,6 @@ async def send_in_session(
     message_version: int = 1,
     encrypted_envelope: dict[str, Any] | None = None,
     encrypted_metadata: dict[str, Any] | None = None,
-    created_at: datetime | None = None,
     message_id: UUID | None = None,
 ) -> dict[str, Any] | None:
     aweb_db = db.get_manager("aweb")
@@ -393,7 +392,10 @@ async def send_in_session(
     if not participant:
         return None
 
-    effective_created_at = created_at if created_at is not None else datetime.now(timezone.utc)
+    # The sender-attested time remains in signed_payload or encrypted_envelope.
+    # created_at is when this server received the message for ordering, so the
+    # two values intentionally use different clocks and may disagree.
+    effective_created_at = datetime.now(timezone.utc)
     effective_message_id = message_id if message_id is not None else uuid_mod.uuid4()
     sender_agent_uuid = _uuid_or_none(sender_agent_id) or participant.get("agent_id")
     encrypted_metadata = encrypted_metadata or {}

--- a/server/src/aweb/messaging/messages.py
+++ b/server/src/aweb/messaging/messages.py
@@ -261,7 +261,6 @@ async def deliver_message(
     message_version: int = 1,
     encrypted_envelope: dict | None = None,
     encrypted_metadata: dict | None = None,
-    created_at: datetime | None = None,
     message_id: UUID | None = None,
     conversation_id: str | UUID | None = None,
     skip_policy_check: bool = False,
@@ -290,8 +289,10 @@ async def deliver_message(
             stored_route_continuation=stored_route_continuation,
         )
 
-    if created_at is None:
-        created_at = datetime.now(timezone.utc)
+    # The sender-attested time remains in signed_payload or encrypted_envelope.
+    # created_at is when this server received the message for ordering, so the
+    # two values intentionally use different clocks and may disagree.
+    created_at = datetime.now(timezone.utc)
     if message_id is None:
         message_id = uuid_mod.uuid4()
 

--- a/server/src/aweb/routes/chat.py
+++ b/server/src/aweb/routes/chat.py
@@ -31,7 +31,12 @@ from aweb.e2ee_messages import (
     encrypted_message_storage_metadata,
     validate_e2ee_message_envelope,
 )
-from aweb.federation.envelope import FederationEnvelope, FederationEnvelopeError, verify_federation_envelope
+from aweb.federation.envelope import (
+    FederationEnvelope,
+    FederationEnvelopeError,
+    enforce_message_timestamp_skew,
+    verify_federation_envelope,
+)
 from aweb.federation.mail import FederatedMailDeliveryError, deliver_federated_message
 from aweb.hooks import fire_mutation_hook
 from aweb.identity_metadata import lookup_identity_metadata_by_did, routable_chat_address
@@ -109,6 +114,10 @@ def _parse_signed_timestamp(value: str) -> datetime:
     dt = _parse_timestamp(value, "timestamp")
     if dt.microsecond != 0:
         raise HTTPException(status_code=422, detail="timestamp must be second precision")
+    try:
+        enforce_message_timestamp_skew(dt)
+    except FederationEnvelopeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return dt
 
 
@@ -131,7 +140,7 @@ def _validate_signed_chat_payload(
     hang_on: bool = False,
 ) -> None:
     if signed_payload is None:
-        return
+        raise HTTPException(status_code=422, detail="signed_payload is required when signature is provided")
     try:
         payload = json.loads(signed_payload)
     except Exception:
@@ -1259,7 +1268,10 @@ async def create_or_send(
                 conversation_id=str(requested_session_id),
                 sender_leaving=payload.leaving,
             )
-        msg_created_at = _parse_signed_timestamp(str(payload.timestamp))
+        # payload.timestamp is sender attestation retained in signed_payload or
+        # encrypted_envelope; send_in_session assigns independent server receipt
+        # time for ordering, so the two values may disagree.
+        _parse_signed_timestamp(str(payload.timestamp))
         pre_message_id = uuid_mod.UUID(str(payload.message_id))
         route = await _resolve_remote_chat_route(
             db,
@@ -1305,7 +1317,6 @@ async def create_or_send(
             message_version=payload.message_version,
             encrypted_envelope=payload.encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=msg_created_at,
             message_id=pre_message_id,
         )
         if msg_row is None:
@@ -1368,7 +1379,6 @@ async def create_or_send(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
     aweb_db = db.get_manager("aweb")
-    msg_created_at = datetime.now(timezone.utc)
     pre_message_id = uuid_mod.uuid4()
 
     encrypted_metadata = _validate_encrypted_chat_payload(
@@ -1380,7 +1390,10 @@ async def create_or_send(
     )
 
     if encrypted_metadata is not None:
-        msg_created_at = _parse_signed_timestamp(str(payload.timestamp))
+        # payload.timestamp is sender attestation retained in encrypted_envelope;
+        # send_in_session assigns independent server receipt time for ordering,
+        # so the two values may disagree.
+        _parse_signed_timestamp(str(payload.timestamp))
         pre_message_id = uuid_mod.UUID(str(payload.message_id))
     elif payload.signature is not None:
         if payload.from_did is None or not payload.from_did.strip():
@@ -1409,7 +1422,10 @@ async def create_or_send(
             conversation_id=validation_conversation_id,
             sender_leaving=payload.leaving,
         )
-        msg_created_at = _parse_signed_timestamp(payload.timestamp)
+        # payload.timestamp is sender attestation retained in signed_payload;
+        # send_in_session assigns independent server receipt time for ordering,
+        # so the two values may disagree.
+        _parse_signed_timestamp(payload.timestamp)
         pre_message_id = uuid_mod.UUID(payload.message_id)
 
     if payload.reply_to is not None:
@@ -1440,7 +1456,6 @@ async def create_or_send(
             message_version=payload.message_version,
             encrypted_envelope=payload.encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=msg_created_at,
             message_id=pre_message_id,
         )
     except Exception as exc:
@@ -2286,7 +2301,6 @@ async def send_message(
     except (ValidationError, NotFoundError, ForbiddenError) as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
-    msg_created_at = datetime.now(timezone.utc)
     pre_message_id = uuid_mod.uuid4()
     encrypted_metadata = _validate_encrypted_chat_payload(
         payload,
@@ -2296,7 +2310,10 @@ async def send_message(
         recipient_rows=recipient_rows,
     )
     if encrypted_metadata is not None:
-        msg_created_at = _parse_signed_timestamp(str(payload.timestamp))
+        # payload.timestamp is sender attestation retained in encrypted_envelope;
+        # send_in_session assigns independent server receipt time for ordering,
+        # so the two values may disagree.
+        _parse_signed_timestamp(str(payload.timestamp))
         pre_message_id = uuid_mod.UUID(str(payload.message_id))
     elif payload.signature is not None:
         if payload.from_did is None or not payload.from_did.strip():
@@ -2324,7 +2341,10 @@ async def send_message(
             sender_leaving=payload.leaving,
             hang_on=payload.hang_on,
         )
-        msg_created_at = _parse_signed_timestamp(payload.timestamp)
+        # payload.timestamp is sender attestation retained in signed_payload;
+        # send_in_session assigns independent server receipt time for ordering,
+        # so the two values may disagree.
+        _parse_signed_timestamp(payload.timestamp)
         pre_message_id = uuid_mod.UUID(payload.message_id)
 
     remote_recipients = [row for row in recipient_rows if _target_delivery_origin(row)]
@@ -2391,7 +2411,6 @@ async def send_message(
                 message_version=payload.message_version,
                 encrypted_envelope=payload.encrypted_envelope,
                 encrypted_metadata=encrypted_metadata,
-                created_at=msg_created_at,
                 message_id=pre_message_id,
             )
         except Exception as exc:
@@ -2448,7 +2467,6 @@ async def send_message(
             message_version=payload.message_version,
             encrypted_envelope=payload.encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=msg_created_at,
             message_id=pre_message_id,
         )
     except Exception as exc:

--- a/server/src/aweb/routes/federation.py
+++ b/server/src/aweb/routes/federation.py
@@ -654,7 +654,6 @@ async def receive_federated_message(
                 message_version=envelope.message_version or 1,
                 encrypted_envelope=envelope.encrypted_envelope,
                 encrypted_metadata=encrypted_metadata,
-                created_at=_parse_timestamp(envelope.timestamp),
                 message_id=UUID(envelope.message_id),
                 conversation_id=conversation_id,
                 skip_policy_check=True,
@@ -683,7 +682,6 @@ async def receive_federated_message(
                 message_version=envelope.message_version or 1,
                 encrypted_envelope=envelope.encrypted_envelope,
                 encrypted_metadata=encrypted_metadata,
-                created_at=_parse_timestamp(envelope.timestamp),
                 message_id=UUID(envelope.message_id),
             )
             if msg_row is None:

--- a/server/src/aweb/routes/messages.py
+++ b/server/src/aweb/routes/messages.py
@@ -19,6 +19,7 @@ from aweb.e2ee_messages import (
 from aweb.federation.envelope import (
     FederationEnvelope,
     FederationEnvelopeError,
+    enforce_message_timestamp_skew,
     verify_federation_envelope,
 )
 from aweb.federation.mail import FederatedMailDeliveryError, deliver_federated_mail
@@ -380,6 +381,10 @@ def _parse_signed_timestamp(value: str) -> datetime:
     dt = dt.astimezone(timezone.utc)
     if dt.microsecond != 0:
         raise HTTPException(status_code=422, detail="timestamp must be second precision")
+    try:
+        enforce_message_timestamp_skew(dt)
+    except FederationEnvelopeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return dt
 
 
@@ -402,7 +407,7 @@ def _validate_signed_mail_payload(
     conversation_id: str | None = None,
 ) -> None:
     if signed_payload is None:
-        return
+        raise HTTPException(status_code=422, detail="signed_payload is required when signature is provided")
     try:
         payload = json.loads(signed_payload)
     except Exception:
@@ -713,7 +718,6 @@ async def _deliver_remote_mail_and_project_locally(
     recipient_did: str,
     to_agent_id: str | None,
     to_alias: str | None,
-    created_at: datetime | None,
     msg_uuid: UUID | None,
 ) -> SendMessageResponse:
     delivery_origin = _remote_delivery_origin(recipient)
@@ -890,7 +894,6 @@ async def _deliver_remote_mail_and_project_locally(
             message_version=payload.message_version or 1,
             encrypted_envelope=payload.encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=created_at,
             message_id=msg_uuid,
             conversation_id=conversation["conversation_id"],
             skip_policy_check=True,
@@ -988,7 +991,6 @@ async def _send_mail_conversation_continuation(
     conversation_id: str,
 ) -> SendMessageResponse:
     msg_uuid = UUID(payload.message_id) if payload.message_id else None
-    created_at = None
 
     try:
         continuation = await mail_continuation_context(
@@ -1038,7 +1040,10 @@ async def _send_mail_conversation_continuation(
                 timestamp=payload.timestamp,
                 conversation_id=conversation_id,
             )
-            created_at = _parse_signed_timestamp(payload.timestamp)
+            # payload.timestamp is the sender's attestation retained in
+            # signed_payload; deliver_message separately assigns server receipt
+            # time for ordering, so the two values may disagree.
+            _parse_signed_timestamp(payload.timestamp)
         encrypted_metadata = _validate_encrypted_payload(
             payload,
             auth=auth,
@@ -1046,7 +1051,7 @@ async def _send_mail_conversation_continuation(
             recipient=recipient,
             recipient_did=recipient_participant["did"],
         )
-        message_id, created_at = await deliver_message(
+        message_id, server_received_at = await deliver_message(
             db,
             registry_client=registry_client,
             recipient_agent=recipient,
@@ -1067,7 +1072,6 @@ async def _send_mail_conversation_continuation(
             message_version=payload.message_version or 1,
             encrypted_envelope=payload.encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=created_at,
             message_id=msg_uuid,
             conversation_id=conversation_id,
             sender_verified_team_id=auth.verified_team_id,
@@ -1101,7 +1105,7 @@ async def _send_mail_conversation_continuation(
         message_id=str(message_id),
         conversation_id=conversation_id,
         status="delivered",
-        delivered_at=_utc_iso(created_at),
+        delivered_at=_utc_iso(server_received_at),
     )
 
 
@@ -1122,7 +1126,8 @@ async def _send_federated_mail_conversation_continuation(
     except (ValidationError, ServiceError) as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     msg_uuid = UUID(payload.message_id) if payload.message_id else None
-    created_at = _parse_signed_timestamp(payload.timestamp) if payload.timestamp else None
+    if payload.timestamp:
+        _parse_signed_timestamp(payload.timestamp)
     return await _deliver_remote_mail_and_project_locally(
         request,
         payload,
@@ -1135,7 +1140,6 @@ async def _send_federated_mail_conversation_continuation(
         recipient_did=recipient_participant["did"],
         to_agent_id=None,
         to_alias=recipient_participant.get("alias"),
-        created_at=created_at,
         msg_uuid=msg_uuid,
     )
 
@@ -1500,7 +1504,6 @@ async def send_message(
         raise HTTPException(status_code=422, detail="Must provide to_did, to_address, to_agent_id, or to_alias")
 
     msg_uuid = UUID(payload.message_id) if payload.message_id else None
-    created_at = None
     if payload.signature is not None:
         if payload.from_did is None or not payload.from_did.strip():
             raise HTTPException(status_code=422, detail="from_did is required when signature is provided")
@@ -1529,7 +1532,10 @@ async def send_message(
             timestamp=payload.timestamp,
             conversation_id=payload.conversation_id,
         )
-        created_at = _parse_signed_timestamp(payload.timestamp)
+        # payload.timestamp is the sender's attestation retained in
+        # signed_payload; deliver_message separately assigns server receipt
+        # time for ordering, so the two values may disagree.
+        _parse_signed_timestamp(payload.timestamp)
 
     if (recipient or {}).get("external"):
         return await _deliver_remote_mail_and_project_locally(
@@ -1544,7 +1550,6 @@ async def send_message(
             recipient_did=recipient_did or "",
             to_agent_id=to_agent_id,
             to_alias=to_alias,
-            created_at=created_at,
             msg_uuid=msg_uuid,
         )
 
@@ -1592,7 +1597,7 @@ async def send_message(
             ],
             team_id=auth.team_id,
         )
-        message_id, created_at = await deliver_message(
+        message_id, server_received_at = await deliver_message(
             db,
             registry_client=registry_client,
             recipient_agent=recipient,
@@ -1613,7 +1618,6 @@ async def send_message(
             message_version=payload.message_version or 1,
             encrypted_envelope=payload.encrypted_envelope,
             encrypted_metadata=encrypted_metadata,
-            created_at=created_at,
             message_id=msg_uuid,
             conversation_id=conversation["conversation_id"],
             skip_policy_check=True,
@@ -1651,7 +1655,7 @@ async def send_message(
         message_id=str(message_id),
         conversation_id=conversation["conversation_id"],
         status="delivered",
-        delivered_at=_utc_iso(created_at),
+        delivered_at=_utc_iso(server_received_at),
     )
 
 

--- a/server/tests/test_chat_http.py
+++ b/server/tests/test_chat_http.py
@@ -2545,7 +2545,7 @@ async def test_create_chat_session_resolves_tilde_alias_cross_team(aweb_cloud_db
     app.dependency_overrides[get_messaging_auth] = _auth_override
 
     message_id = str(uuid4())
-    timestamp = "2026-04-17T12:00:00Z"
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     signed_payload = json.dumps(
         {
             "type": "chat",
@@ -3270,9 +3270,137 @@ async def test_create_chat_session_to_private_address_rejects_unverified_client_
     assert "Recipient address not found" in resp.text
 
 
+async def _signed_local_chat_app(aweb_cloud_db):
+    alice_sk, _, alice_did_key = _make_keypair()
+    await aweb_cloud_db.aweb_db.execute(
+        """
+        INSERT INTO {{tables.teams}} (team_id, namespace, team_name, team_did_key)
+        VALUES ('backend:timestamp.example', 'timestamp.example', 'backend', 'did:key:team-timestamp')
+        """
+    )
+    await aweb_cloud_db.aweb_db.execute(
+        """
+        INSERT INTO {{tables.agents}} (team_id, did_key, did_aw, address, alias, identity_scope, role, inbound_mode)
+        VALUES
+            ('backend:timestamp.example', $1, 'did:aw:alice-timestamp', 'timestamp.example/alice', 'alice', 'global', 'developer', 'open'),
+            ('backend:timestamp.example', 'did:key:bob-timestamp', 'did:aw:bob-timestamp', 'timestamp.example/bob', 'bob', 'global', 'developer', 'open')
+        """,
+        alice_did_key,
+    )
+    app = _build_test_app(aweb_cloud_db.aweb_db, AsyncMock())
+
+    async def _auth():
+        return MessagingAuth(
+            did_key=alice_did_key,
+            did_aw="did:aw:alice-timestamp",
+            address="timestamp.example/alice",
+            team_id="backend:timestamp.example",
+            alias="alice",
+        )
+
+    app.dependency_overrides[get_messaging_auth] = _auth
+    return app, alice_sk, alice_did_key
+
+
+def _signed_local_chat_payload(alice_sk, alice_did_key, *, timestamp, include_signed_payload=True):
+    session_id = str(uuid4())
+    message_id = str(uuid4())
+    signed_payload = canonical_json_bytes(
+        {
+            "body": "timestamp body",
+            "conversation_id": session_id,
+            "from": "alice",
+            "from_did": alice_did_key,
+            "message_id": message_id,
+            "subject": "",
+            "timestamp": timestamp,
+            "to": "bob",
+            "to_did": "",
+            "type": "chat",
+        }
+    )
+    payload = {
+        "session_id": session_id,
+        "to_aliases": ["bob"],
+        "message": "timestamp body",
+        "from_did": alice_did_key,
+        "message_id": message_id,
+        "timestamp": timestamp,
+        "signature": sign_message(alice_sk, signed_payload),
+    }
+    if include_signed_payload:
+        payload["signed_payload"] = signed_payload.decode()
+    return message_id, payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("offset_seconds", [-360, 360])
+async def test_signed_plaintext_chat_rejects_timestamp_outside_federation_window(
+    aweb_cloud_db, offset_seconds
+):
+    app, alice_sk, alice_did_key = await _signed_local_chat_app(aweb_cloud_db)
+    timestamp = (
+        datetime.now(timezone.utc).replace(microsecond=0) + timedelta(seconds=offset_seconds)
+    ).isoformat().replace("+00:00", "Z")
+    _, payload = _signed_local_chat_payload(
+        alice_sk,
+        alice_did_key,
+        timestamp=timestamp,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/chat/sessions", json=payload)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "timestamp outside accepted skew"
+
+
+@pytest.mark.asyncio
+async def test_signed_plaintext_chat_stores_server_time_and_preserves_attestation(aweb_cloud_db):
+    app, alice_sk, alice_did_key = await _signed_local_chat_app(aweb_cloud_db)
+    attested_at = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=4)
+    message_id, payload = _signed_local_chat_payload(
+        alice_sk,
+        alice_did_key,
+        timestamp=attested_at.isoformat().replace("+00:00", "Z"),
+    )
+
+    before = datetime.now(timezone.utc)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/chat/sessions", json=payload)
+    after = datetime.now(timezone.utc)
+
+    assert response.status_code == 200, response.text
+    row = await aweb_cloud_db.aweb_db.fetch_one(
+        "SELECT created_at, signed_payload FROM {{tables.chat_messages}} WHERE message_id = $1",
+        UUID(message_id),
+    )
+    assert before <= row["created_at"] <= after
+    assert row["created_at"] != attested_at
+    assert json.loads(row["signed_payload"])["timestamp"] == payload["timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_signed_plaintext_chat_requires_signed_payload(aweb_cloud_db):
+    app, alice_sk, alice_did_key = await _signed_local_chat_app(aweb_cloud_db)
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    _, payload = _signed_local_chat_payload(
+        alice_sk,
+        alice_did_key,
+        timestamp=timestamp,
+        include_signed_payload=False,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/chat/sessions", json=payload)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "signed_payload is required when signature is provided"
+
+
 @pytest.mark.asyncio
 async def test_create_chat_session_accepts_signed_from_did_key_for_team_context(aweb_cloud_db):
-    _, _, alice_did_key = _make_keypair()
+    alice_sk, _, alice_did_key = _make_keypair()
     await aweb_cloud_db.aweb_db.execute(
         """
         INSERT INTO {{tables.teams}} (team_id, namespace, team_name, team_did_key)
@@ -3303,13 +3431,29 @@ async def test_create_chat_session_accepts_signed_from_did_key_for_team_context(
 
     app.dependency_overrides[get_messaging_auth] = _team_auth_override
 
+    message_id = "11111111-1111-4111-8111-111111111111"
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    signed_payload = canonical_json_bytes(
+        {
+            "body": "hello bob",
+            "from": "alice",
+            "from_did": alice_did_key,
+            "message_id": message_id,
+            "subject": "",
+            "timestamp": timestamp,
+            "to": "bob",
+            "to_did": "",
+            "type": "chat",
+        }
+    )
     payload = {
         "to_aliases": ["bob"],
         "message": "hello bob",
         "from_did": alice_did_key,
-        "signature": "sig",
-        "message_id": "11111111-1111-4111-8111-111111111111",
-        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "signature": sign_message(alice_sk, signed_payload),
+        "signed_payload": signed_payload.decode(),
+        "message_id": message_id,
+        "timestamp": timestamp,
     }
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post("/v1/chat/sessions", json=payload)
@@ -3775,7 +3919,7 @@ async def test_create_chat_session_rejects_signed_payload_from_mismatch(aweb_clo
 
 @pytest.mark.asyncio
 async def test_chat_send_message_accepts_signed_from_did_key_for_team_context(aweb_cloud_db):
-    _, _, alice_did_key = _make_keypair()
+    alice_sk, _, alice_did_key = _make_keypair()
     await aweb_cloud_db.aweb_db.execute(
         """
         INSERT INTO {{tables.teams}} (team_id, namespace, team_name, team_did_key)
@@ -3812,12 +3956,29 @@ async def test_chat_send_message_accepts_signed_from_did_key_for_team_context(aw
 
     app.dependency_overrides[get_messaging_auth] = _team_auth_override
 
+    message_id = "22222222-2222-4222-8222-222222222222"
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    signed_payload = canonical_json_bytes(
+        {
+            "body": "follow-up",
+            "conversation_id": str(session_id),
+            "from": "alice",
+            "from_did": alice_did_key,
+            "message_id": message_id,
+            "subject": "",
+            "timestamp": timestamp,
+            "to": "bob",
+            "to_did": "",
+            "type": "chat",
+        }
+    )
     payload = {
         "body": "follow-up",
         "from_did": alice_did_key,
-        "signature": "sig",
-        "message_id": "22222222-2222-4222-8222-222222222222",
-        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "signature": sign_message(alice_sk, signed_payload),
+        "signed_payload": signed_payload.decode(),
+        "message_id": message_id,
+        "timestamp": timestamp,
     }
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(f"/v1/chat/sessions/{session_id}/messages", json=payload)

--- a/server/tests/test_federation_envelope.py
+++ b/server/tests/test_federation_envelope.py
@@ -8,7 +8,11 @@ from pydantic import ValidationError
 
 from awid.did import did_from_public_key, generate_keypair, stable_id_from_did_key
 from awid.signing import canonical_json_bytes, sign_message
-from aweb.federation.envelope import FederationEnvelopeError, verify_federation_envelope
+from aweb.federation.envelope import (
+    FederationEnvelopeError,
+    enforce_message_timestamp_skew,
+    verify_federation_envelope,
+)
 
 
 def _timestamp(offset_seconds: int = 0) -> str:
@@ -352,6 +356,17 @@ def test_verify_federation_envelope_rejects_invalid_signature():
 
     with pytest.raises(FederationEnvelopeError, match="Invalid federation message signature"):
         verify_federation_envelope(envelope, signature)
+
+
+def test_message_timestamp_skew_window_is_exactly_300_seconds():
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+
+    enforce_message_timestamp_skew(now - timedelta(seconds=300), now=now)
+    enforce_message_timestamp_skew(now + timedelta(seconds=300), now=now)
+    with pytest.raises(FederationEnvelopeError, match="timestamp outside accepted skew"):
+        enforce_message_timestamp_skew(now - timedelta(seconds=301), now=now)
+    with pytest.raises(FederationEnvelopeError, match="timestamp outside accepted skew"):
+        enforce_message_timestamp_skew(now + timedelta(seconds=301), now=now)
 
 
 def test_verify_federation_envelope_rejects_stale_timestamp():

--- a/server/tests/test_messages_http.py
+++ b/server/tests/test_messages_http.py
@@ -2254,6 +2254,140 @@ async def test_signed_continuation_requires_matching_conversation_id(aweb_cloud_
     assert "conversation_id" in resp.json()["detail"]
 
 
+async def _signed_local_mail_app(aweb_cloud_db):
+    alice_sk, _, alice_did_key = _make_keypair()
+    _, _, bob_did_key = _make_keypair()
+    await _insert_team(aweb_cloud_db.aweb_db, "backend:timestamp.example")
+    alice_agent_id = await _insert_agent(
+        aweb_cloud_db.aweb_db,
+        team_id="backend:timestamp.example",
+        alias="alice",
+        did_key=alice_did_key,
+        did_aw="did:aw:alice-timestamp",
+        address="timestamp.example/alice",
+    )
+    await _insert_agent(
+        aweb_cloud_db.aweb_db,
+        team_id="backend:timestamp.example",
+        alias="bob",
+        did_key=bob_did_key,
+        did_aw="did:aw:bob-timestamp",
+        address="timestamp.example/bob",
+    )
+    app = _build_test_app(aweb_cloud_db.aweb_db, AsyncMock())
+
+    async def _auth():
+        return MessagingAuth(
+            did_key=alice_did_key,
+            did_aw="did:aw:alice-timestamp",
+            address="timestamp.example/alice",
+            team_id="backend:timestamp.example",
+            alias="alice",
+            agent_id=alice_agent_id,
+        )
+
+    app.dependency_overrides[get_messaging_auth] = _auth
+    return app, alice_sk, alice_did_key
+
+
+def _signed_local_mail_payload(alice_sk, alice_did_key, *, timestamp, subject, include_signed_payload=True):
+    message_id = str(uuid4())
+    signed_payload = canonical_json_bytes(
+        {
+            "body": "timestamp body",
+            "from": "alice",
+            "from_did": alice_did_key,
+            "message_id": message_id,
+            "subject": subject,
+            "timestamp": timestamp,
+            "to": "did:aw:bob-timestamp",
+            "to_did": "did:aw:bob-timestamp",
+            "type": "mail",
+        }
+    )
+    payload = {
+        "to_did": "did:aw:bob-timestamp",
+        "subject": subject,
+        "body": "timestamp body",
+        "from_did": alice_did_key,
+        "message_id": message_id,
+        "timestamp": timestamp,
+        "signature": sign_message(alice_sk, signed_payload),
+    }
+    if include_signed_payload:
+        payload["signed_payload"] = signed_payload.decode()
+    return message_id, payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("offset_seconds", [-360, 360])
+async def test_signed_plaintext_mail_rejects_timestamp_outside_federation_window(
+    aweb_cloud_db, offset_seconds
+):
+    app, alice_sk, alice_did_key = await _signed_local_mail_app(aweb_cloud_db)
+    timestamp = (
+        datetime.now(timezone.utc).replace(microsecond=0) + timedelta(seconds=offset_seconds)
+    ).isoformat().replace("+00:00", "Z")
+    _, payload = _signed_local_mail_payload(
+        alice_sk,
+        alice_did_key,
+        timestamp=timestamp,
+        subject=f"mail skew {offset_seconds}",
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/messages", json=payload)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "timestamp outside accepted skew"
+
+
+@pytest.mark.asyncio
+async def test_signed_plaintext_mail_stores_server_time_and_preserves_attestation(aweb_cloud_db):
+    app, alice_sk, alice_did_key = await _signed_local_mail_app(aweb_cloud_db)
+    attested_at = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=4)
+    message_id, payload = _signed_local_mail_payload(
+        alice_sk,
+        alice_did_key,
+        timestamp=attested_at.isoformat().replace("+00:00", "Z"),
+        subject="mail separate timestamps",
+    )
+
+    before = datetime.now(timezone.utc)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/messages", json=payload)
+    after = datetime.now(timezone.utc)
+
+    assert response.status_code == 200, response.text
+    row = await aweb_cloud_db.aweb_db.fetch_one(
+        "SELECT created_at, signed_payload FROM {{tables.messages}} WHERE message_id = $1",
+        UUID(message_id),
+    )
+    assert before <= row["created_at"] <= after
+    assert row["created_at"] != attested_at
+    assert json.loads(row["signed_payload"])["timestamp"] == payload["timestamp"]
+    assert datetime.fromisoformat(response.json()["delivered_at"]) == row["created_at"].replace(microsecond=0)
+
+
+@pytest.mark.asyncio
+async def test_signed_plaintext_mail_requires_signed_payload(aweb_cloud_db):
+    app, alice_sk, alice_did_key = await _signed_local_mail_app(aweb_cloud_db)
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    _, payload = _signed_local_mail_payload(
+        alice_sk,
+        alice_did_key,
+        timestamp=timestamp,
+        subject="mail missing attestation",
+        include_signed_payload=False,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/messages", json=payload)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "signed_payload is required when signature is provided"
+
+
 @pytest.mark.asyncio
 async def test_signed_legacy_first_mail_status_is_visible_and_allows_continuation(aweb_cloud_db):
     alice_sk, _, alice_did_key = _make_keypair()
@@ -5544,7 +5678,7 @@ async def test_send_message_resolves_tilde_alias_cross_team(aweb_cloud_db):
     app.dependency_overrides[get_messaging_auth] = _auth_override
 
     message_id = str(uuid4())
-    timestamp = "2026-04-17T12:00:00Z"
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     signed_payload = json.dumps(
         {
             "type": "mail",


### PR DESCRIPTION
## Summary

- make `messages.created_at` and `chat_messages.created_at` server receipt time by removing the caller override from both storage APIs
- preserve sender-attested time in `signed_payload` or the encrypted envelope, with comments explaining why it intentionally differs from server receipt time
- require `signed_payload` for newly signed plaintext mail/chat and apply the already-shipped federation ±300-second skew policy to local routes
- keep E2EE envelope construction unchanged; its `created_at` is attestation, not storage ordering
- update every aweb mail/chat route, federation, and MCP caller; no schema migration, repair, backfill, or historical rewrite
- pin the exact 300-second boundary with an injected fixed clock

## Evidence

- real-route/PostgreSQL probe established the defect with signed 2000/current/2099 plaintext mail and independently refuted E2EE builder ownership
- focused route tests prove local mail/chat reject ±360-second skew, reject signature without signed payload, and store server time while retaining the signed timestamp
- deterministic boundary test accepts exactly ±300 and rejects ±301
- production constant mutation 300→350 makes the deterministic guard red for the intended missing exception
- `make test`: PASS
  - server: 687
  - awid: 225
  - full Go suite
  - channel: 19
  - OAS: 31
- `scripts/check-freshness.sh`: PASS
- `git diff --check`: PASS

## Scope boundary

This is step 1 only. Server wall time is not a monotonic insertion cursor: it can tie or move backwards. This PR does **not** close the constructed concurrent chat watermark race and must not close `default-aamm`. BIGSERIAL and exact-ID read semantics remain separate coordinated slices.

Existing rows remain unchanged by explicit Juan decision. Previously stored far-future values may remain pinned.
