### PR TITLE
chore(server): bump version to 1.26.26

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aweb"
-version = "1.26.25"
+version = "1.26.26"
 description = "Agent Web: self-hostable coordination server for AI agents (identity, presence, mail, chat, tasks, locks)"
 readme = "README.md"
 license = "MIT"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "aweb"
-version = "1.26.25"
+version = "1.26.26"
 source = { editable = "." }
 dependencies = [
     { name = "awid-service" },


### PR DESCRIPTION
PR #20 merged default-aamm step 1 at `ee4a258d`, but its Server CI version-bump guard correctly failed because the server package remained 1.26.25.

This follow-up contains only the required server version bump to 1.26.26 and regenerated `server/uv.lock`.

Evidence after syncing current main:
- `./scripts/check-server-version-bump.sh origin/main` PASS
- server suite: 688 PASS
- full Go suite PASS; the one hosted broken-pipe failure from PR #20 passed both targeted and full local reruns
- freshness, including negative fixtures: PASS

No tags, release, publish, or deploy.
