### PR TITLE
aajc.12b: transaction ownership and a supported rotation recover/resume/status command

### DIFF
--- a/cli/go/awconfig/lock_error.go
+++ b/cli/go/awconfig/lock_error.go
@@ -1,0 +1,5 @@
+package awconfig
+
+import "errors"
+
+var ErrLockUnavailable = errors.New("lock is held by another process")

--- a/cli/go/awconfig/lock_unix.go
+++ b/cli/go/awconfig/lock_unix.go
@@ -13,15 +13,38 @@ type fileLock struct {
 }
 
 func LockExclusive(lockPath string) (*fileLock, error) {
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
-		return nil, err
+	return lockExclusive(lockPath, false, true)
+}
+
+func TryLockExclusive(lockPath string) (*fileLock, error) {
+	return lockExclusive(lockPath, true, true)
+}
+
+func TryLockExistingExclusive(lockPath string) (*fileLock, error) {
+	return lockExclusive(lockPath, true, false)
+}
+
+func lockExclusive(lockPath string, nonBlocking, create bool) (*fileLock, error) {
+	flags := os.O_RDWR
+	if create {
+		if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+			return nil, err
+		}
+		flags |= os.O_CREATE
 	}
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	f, err := os.OpenFile(lockPath, flags, 0o600)
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	operation := syscall.LOCK_EX
+	if nonBlocking {
+		operation |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(f.Fd()), operation); err != nil {
 		_ = f.Close()
+		if nonBlocking && (err == syscall.EWOULDBLOCK || err == syscall.EAGAIN) {
+			return nil, ErrLockUnavailable
+		}
 		return nil, err
 	}
 	return &fileLock{f: f}, nil

--- a/cli/go/awconfig/lock_windows.go
+++ b/cli/go/awconfig/lock_windows.go
@@ -14,19 +14,42 @@ type fileLock struct {
 }
 
 func LockExclusive(lockPath string) (*fileLock, error) {
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
-		return nil, err
+	return lockExclusive(lockPath, false, true)
+}
+
+func TryLockExclusive(lockPath string) (*fileLock, error) {
+	return lockExclusive(lockPath, true, true)
+}
+
+func TryLockExistingExclusive(lockPath string) (*fileLock, error) {
+	return lockExclusive(lockPath, true, false)
+}
+
+func lockExclusive(lockPath string, nonBlocking, create bool) (*fileLock, error) {
+	openFlags := os.O_RDWR
+	if create {
+		if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+			return nil, err
+		}
+		openFlags |= os.O_CREATE
 	}
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	f, err := os.OpenFile(lockPath, openFlags, 0o600)
 	if err != nil {
 		return nil, err
 	}
 
 	handle := windows.Handle(f.Fd())
 	var ol windows.Overlapped
+	lockFlags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK)
+	if nonBlocking {
+		lockFlags |= windows.LOCKFILE_FAIL_IMMEDIATELY
+	}
 	// Lock a single byte as a global mutex for this config path.
-	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol); err != nil {
+	if err := windows.LockFileEx(handle, lockFlags, 0, 1, 0, &ol); err != nil {
 		_ = f.Close()
+		if nonBlocking && err == windows.ERROR_LOCK_VIOLATION {
+			return nil, ErrLockUnavailable
+		}
 		return nil, err
 	}
 	return &fileLock{f: f}, nil

--- a/cli/go/cmd/aw/id_commands_test.go
+++ b/cli/go/cmd/aw/id_commands_test.go
@@ -1581,7 +1581,7 @@ func TestAwIDRotateKeyRotatesStandaloneIdentityAndUpdatesLocalState(t *testing.T
 	}
 }
 
-func TestAwIDRotateKeyRefusesWhenPendingRotationExists(t *testing.T) {
+func TestAwIDRotateKeyPreservesPendingRotationWhenRecoveryIsUnknown(t *testing.T) {
 	t.Parallel()
 
 	pub, priv, err := awid.GenerateKeypair()
@@ -1609,11 +1609,13 @@ func TestAwIDRotateKeyRefusesWhenPendingRotationExists(t *testing.T) {
 		t.Fatal(err)
 	}
 	pendingDID := awid.ComputeDIDKey(pendingPub)
-	pendingKeyPath, err := savePendingRotationKeypair(rotationDir, pendingDID, pendingPub, pendingPriv)
+	operationID := "11111111-1111-4111-8111-111111111111"
+	pendingKeyPath, err := savePendingRotationKeypair(rotationDir, operationID, pendingPub, pendingPriv)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := savePendingRotationState(rotationDir, &pendingRotationState{
+		OperationID: operationID,
 		StableID:    stableID,
 		OldDID:      did,
 		NewDID:      pendingDID,
@@ -1627,11 +1629,18 @@ func TestAwIDRotateKeyRefusesWhenPendingRotationExists(t *testing.T) {
 	run.Env = testCommandEnv(tmp)
 	run.Dir = tmp
 	out, err := run.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected rotate-key to fail\n%s", string(out))
+	if err != nil {
+		t.Fatalf("expected an unknown-preserved recovery result: %v\n%s", err, string(out))
 	}
-	if !strings.Contains(string(out), "pending rotation exists") {
-		t.Fatalf("unexpected error output:\n%s", string(out))
+	for _, want := range []string{"unknown_preserved", "rerun_required", pendingRotationStatePath(rotationDir, stableID)} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("recovery output missing %q:\n%s", want, string(out))
+		}
+	}
+	if pending, err := loadPendingRotationState(rotationDir, stableID); err != nil {
+		t.Fatal(err)
+	} else if pending == nil || pending.OperationID != operationID {
+		t.Fatalf("pending state was not preserved: %+v", pending)
 	}
 }
 

--- a/cli/go/cmd/aw/id_rotate_key.go
+++ b/cli/go/cmd/aw/id_rotate_key.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"os"
@@ -18,6 +17,7 @@ import (
 var idRotateKeyCmd = &cobra.Command{
 	Use:   "rotate-key",
 	Short: "Rotate the current global identity signing key at the registry",
+	Args:  cobra.NoArgs,
 	RunE:  runIDRotateKey,
 }
 
@@ -75,6 +75,17 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	if err := requirePersistentSelfCustodialIdentity(identity, signingKey); err != nil {
 		return err
 	}
+	if pending, err := loadPendingRotationState(rotationDir, identity.StableID); err != nil {
+		return err
+	} else if pending != nil {
+		out, recoverErr := recoverPendingRotation(ctx, identity, rotationDir)
+		if recoverErr != nil {
+			return recoverErr
+		}
+		out.RerunRequired = true
+		printOutput(out, formatIDRotationRecovery)
+		return nil
+	}
 	registry, err := resolveIdentityRegistryClient(identity)
 	if err != nil {
 		return err
@@ -83,20 +94,14 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	if pending, err := loadPendingRotationState(rotationDir, identity.StableID); err != nil {
-		return err
-	} else if pending != nil {
-		return usageError(
-			"pending rotation exists for %s at %s; resolve it before starting another key rotation",
-			identity.StableID,
-			pendingRotationStatePath(rotationDir, identity.StableID),
-		)
-	}
 	if err := os.MkdirAll(filepath.Join(rotationDir, "pending"), 0o700); err != nil {
 		return err
 	}
 
+	operationID, err := awid.GenerateUUID4()
+	if err != nil {
+		return err
+	}
 	newPub, newPriv, err := awid.GenerateKeypair()
 	if err != nil {
 		return err
@@ -107,19 +112,24 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("generated replacement did:key unexpectedly matched the current did:key")
 	}
 
-	pendingKeyPath, err := savePendingRotationKeypair(rotationDir, newDID, newPub, newPriv)
-	if err != nil {
-		return err
-	}
+	pendingKeyPath, _ := pendingRotationKeyPaths(rotationDir, operationID)
 	pendingState := &pendingRotationState{
+		OperationID: operationID,
 		StableID:    identity.StableID,
 		OldDID:      oldDID,
 		NewDID:      newDID,
 		RegistryURL: registryURL,
 		PendingKey:  pendingKeyPath,
 	}
+	// Persist transaction ownership before key material. A crash in between is
+	// recoverable as definitely-not-submitted; the reverse order leaves an
+	// undiscoverable private key with no operation record.
 	if err := savePendingRotationState(rotationDir, pendingState); err != nil {
+		return err
+	}
+	if _, err := savePendingRotationKeypair(rotationDir, operationID, newPub, newPriv); err != nil {
 		_ = cleanupPendingRotationKeypair(pendingKeyPath)
+		_ = removePendingRotationStateOwned(rotationDir, identity.StableID, operationID)
 		return err
 	}
 
@@ -130,7 +140,7 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 			if cleanupErr := cleanupPendingRotationKeypair(pendingKeyPath); cleanupErr != nil {
 				return fmt.Errorf("%w; failed to discard the unused replacement signing key: %v", err, cleanupErr)
 			}
-			if cleanupErr := removePendingRotationState(rotationDir, identity.StableID); cleanupErr != nil {
+			if cleanupErr := removePendingRotationStateOwned(rotationDir, identity.StableID, operationID); cleanupErr != nil {
 				return fmt.Errorf("%w; failed to remove pending rotation state: %v", err, cleanupErr)
 			}
 			return err
@@ -162,32 +172,8 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	if _, err := promotePendingRotationKeypair(identity.SigningKeyPath, pendingKeyPath, newDID); err != nil {
-		return rotationFinalizeError(rotationDir, identity.StableID, "failed to activate the new local signing key", err)
-	}
-
-	state, err := awconfig.LoadWorktreeIdentityFrom(identity.IdentityPath)
-	if err != nil {
-		return rotationFinalizeError(rotationDir, identity.StableID, "failed to reload local identity state", err)
-	}
-	state.DID = newDID
-	state.RegistryStatus = "registered"
-	if strings.TrimSpace(registryURL) != "" {
-		state.RegistryURL = registryURL
-	}
-	if err := awconfig.SaveWorktreeIdentityTo(identity.IdentityPath, state); err != nil {
-		return rotationFinalizeError(rotationDir, identity.StableID, "failed to update local identity state", err)
-	}
-
-	if err := awid.ArchiveKey(filepath.Dir(identity.SigningKeyPath), oldDID, signingKey.Public().(ed25519.PublicKey), signingKey); err != nil {
-		return rotationFinalizeError(rotationDir, identity.StableID, "failed to archive the previous signing key", err)
-	}
-
-	if err := removePendingRotationState(rotationDir, identity.StableID); err != nil {
-		return rotationFinalizeError(rotationDir, identity.StableID, "failed to remove pending rotation state", err)
-	}
-	if err := cleanupPendingRotationKeypair(pendingKeyPath); err != nil {
-		return rotationFinalizeError(rotationDir, identity.StableID, "failed to clean pending rotation key material", err)
+	if err := finalizePendingRotation(identity, rotationDir, pendingState); err != nil {
+		return rotationFinalizeError(rotationDir, identity.StableID, "failed to finalize the applied rotation", err)
 	}
 
 	printOutput(idRotateOutput{

--- a/cli/go/cmd/aw/id_rotate_key_concurrency_test.go
+++ b/cli/go/cmd/aw/id_rotate_key_concurrency_test.go
@@ -361,6 +361,146 @@ func TestConcurrentRotationRefusesIdentityChangedWhileWaiting(t *testing.T) {
 	}
 }
 
+func TestConcurrentWaiterRecoversAppliedRotationAfterLostResponse(t *testing.T) {
+	oldPublic, oldPrivate, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	thirdPublic, _, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPublic)
+	thirdDID := awid.ComputeDIDKey(thirdPublic)
+	stableID := awid.ComputeStableID(oldPublic)
+
+	putArrived := make(chan struct{})
+	releasePut := make(chan struct{})
+	allowRecovery := make(chan struct{})
+	var mu sync.Mutex
+	committedDID := ""
+	putCalls := 0
+	postPutKeyReads := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		committed := committedDID
+		mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/did/"+stableID+"/full":
+			current := oldDID
+			if committed != "" {
+				current = committed
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"did_aw": stableID, "current_did_key": current,
+				"created_at": "2026-07-24T00:00:00Z", "updated_at": "2026-07-24T00:00:00Z",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/did/"+stableID+"/key":
+			mu.Lock()
+			if committedDID != "" {
+				postPutKeyReads++
+			}
+			readNumber := postPutKeyReads
+			current := committedDID
+			mu.Unlock()
+			if readNumber == 1 {
+				// The first process has lost the successful response and cannot
+				// establish the authoritative outcome, so it must preserve state.
+				current = thirdDID
+			} else if readNumber > 1 {
+				<-allowRecovery
+			}
+			if current == "" {
+				current = oldDID
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"did_aw": stableID, "current_did_key": current,
+				"log_head": map[string]any{
+					"seq": 1, "operation": "register_did", "new_did_key": oldDID,
+					"entry_hash": strings.Repeat("a", 64), "state_hash": strings.Repeat("b", 64),
+					"authorized_by": oldDID, "signature": "test", "timestamp": "2026-07-24T00:00:00Z",
+				},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/did/"+stableID:
+			var request map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Error(err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			putCalls++
+			call := putCalls
+			if call == 1 {
+				committedDID, _ = request["new_did_key"].(string)
+			}
+			mu.Unlock()
+			if call != 1 {
+				http.Error(w, "rotation definitely not applied", http.StatusConflict)
+				return
+			}
+			close(putArrived)
+			<-releasePut
+			connection, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_ = connection.Close()
+		default:
+			t.Errorf("unexpected registry request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "aw")
+	buildAwBinary(t, ctx, bin)
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, server.URL, oldPrivate)
+
+	first := startRotationCommand(t, ctx, bin, dir)
+	select {
+	case <-putArrived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first rotation did not reach the registry")
+	}
+	waiter := startRotationCommand(t, ctx, bin, dir)
+	time.Sleep(200 * time.Millisecond)
+	close(releasePut)
+	firstErr := <-first.done
+	if firstErr == nil || !strings.Contains(first.output.String(), "outcome unknown") {
+		t.Fatalf("first rotation error=%v, want preserved unknown outcome\n%s", firstErr, first.output)
+	}
+	close(allowRecovery)
+	if waiterErr := <-waiter.done; waiterErr != nil {
+		t.Fatalf("waiting rotation did not recover the committed operation: %v\n%s", waiterErr, waiter.output)
+	}
+	for _, want := range []string{"\"status\": \"finalized\"", "\"rerun_required\": true"} {
+		if !strings.Contains(waiter.output.String(), want) {
+			t.Fatalf("waiter output missing %q:\n%s", want, waiter.output)
+		}
+	}
+	mu.Lock()
+	gotCommitted, gotPutCalls := committedDID, putCalls
+	mu.Unlock()
+	if gotPutCalls != 1 {
+		t.Fatalf("rotation PUT calls=%d, want only the applied first operation", gotPutCalls)
+	}
+	identity := loadIdentityForTest(t, dir)
+	if identity.DID != gotCommitted {
+		t.Fatalf("local identity did=%q, want recovered registry key %q", identity.DID, gotCommitted)
+	}
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	if pending, err := loadPendingRotationState(rotationDir, stableID); err != nil {
+		t.Fatal(err)
+	} else if pending != nil {
+		t.Fatalf("pending state remains after waiter recovery: %+v", pending)
+	}
+}
+
 type runningRotationCommand struct {
 	done   <-chan error
 	output *bytes.Buffer

--- a/cli/go/cmd/aw/id_rotate_key_outcome_test.go
+++ b/cli/go/cmd/aw/id_rotate_key_outcome_test.go
@@ -19,15 +19,16 @@ import (
 )
 
 type cliRotationRegistryFixture struct {
-	t           *testing.T
-	server      *httptest.Server
-	stableID    string
-	oldDID      string
-	mu          sync.Mutex
-	currentDID  string
-	proposedDID string
-	putCalls    int
-	onPut       func(*cliRotationRegistryFixture, http.ResponseWriter, map[string]any)
+	t             *testing.T
+	server        *httptest.Server
+	stableID      string
+	oldDID        string
+	mu            sync.Mutex
+	currentDID    string
+	responseDIDAW *string
+	proposedDID   string
+	putCalls      int
+	onPut         func(*cliRotationRegistryFixture, http.ResponseWriter, map[string]any)
 }
 
 func newCLIRotationRegistryFixture(
@@ -37,7 +38,8 @@ func newCLIRotationRegistryFixture(
 	onPut func(*cliRotationRegistryFixture, http.ResponseWriter, map[string]any),
 ) *cliRotationRegistryFixture {
 	t.Helper()
-	fixture := &cliRotationRegistryFixture{t: t, stableID: stableID, oldDID: oldDID, currentDID: oldDID, onPut: onPut}
+	responseDIDAW := stableID
+	fixture := &cliRotationRegistryFixture{t: t, stableID: stableID, oldDID: oldDID, currentDID: oldDID, responseDIDAW: &responseDIDAW, onPut: onPut}
 	fixture.server = httptest.NewServer(http.HandlerFunc(fixture.handle))
 	t.Cleanup(fixture.server.Close)
 	return fixture
@@ -49,15 +51,17 @@ func (f *cliRotationRegistryFixture) handle(w http.ResponseWriter, r *http.Reque
 
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/did/"+f.stableID+"/full":
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"did_aw":          f.stableID,
+		response := map[string]any{
 			"current_did_key": f.currentDID,
 			"created_at":      "2026-07-24T00:00:00Z",
 			"updated_at":      "2026-07-24T00:00:00Z",
-		})
+		}
+		if f.responseDIDAW != nil {
+			response["did_aw"] = *f.responseDIDAW
+		}
+		_ = json.NewEncoder(w).Encode(response)
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/did/"+f.stableID+"/key":
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"did_aw":          f.stableID,
+		response := map[string]any{
 			"current_did_key": f.currentDID,
 			"log_head": map[string]any{
 				"seq":           1,
@@ -69,7 +73,11 @@ func (f *cliRotationRegistryFixture) handle(w http.ResponseWriter, r *http.Reque
 				"signature":     "test",
 				"timestamp":     "2026-07-24T00:00:00Z",
 			},
-		})
+		}
+		if f.responseDIDAW != nil {
+			response["did_aw"] = *f.responseDIDAW
+		}
+		_ = json.NewEncoder(w).Encode(response)
 	case r.Method == http.MethodPut && r.URL.Path == "/v1/did/"+f.stableID:
 		f.putCalls++
 		var request map[string]any
@@ -164,15 +172,24 @@ func TestAwIDRotateKeyDiscardsPendingKeyOnlyWhenRegistryProvesNotApplied(t *test
 	}
 	oldDID := awid.ComputeDIDKey(oldPublic)
 	stableID := awid.ComputeStableID(oldPublic)
-	fixture := newCLIRotationRegistryFixture(t, stableID, oldDID, func(_ *cliRotationRegistryFixture, w http.ResponseWriter, _ map[string]any) {
-		http.Error(w, "rotation rejected", http.StatusConflict)
-	})
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	tmp := t.TempDir()
 	bin := filepath.Join(tmp, "aw")
 	buildAwBinary(t, ctx, bin)
+	rotationDir := filepath.Join(tmp, ".aw", "rotation")
+	claimedKeyPath := make(chan string, 1)
+	fixture := newCLIRotationRegistryFixture(t, stableID, oldDID, func(_ *cliRotationRegistryFixture, w http.ResponseWriter, _ map[string]any) {
+		pending, loadErr := loadPendingRotationState(rotationDir, stableID)
+		if loadErr != nil {
+			t.Error(loadErr)
+		} else if pending == nil {
+			t.Error("rotation PUT has no pending operation state")
+		} else {
+			claimedKeyPath <- pending.PendingKey
+		}
+		http.Error(w, "rotation rejected", http.StatusConflict)
+	})
 	writeStandaloneSelfCustodyIdentity(t, tmp, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPrivate)
 
 	out, err := runRotateKeyCommand(ctx, bin, tmp)
@@ -182,17 +199,29 @@ func TestAwIDRotateKeyDiscardsPendingKeyOnlyWhenRegistryProvesNotApplied(t *test
 	if !strings.Contains(string(out), "definitely not applied") {
 		t.Fatalf("unexpected error output:\n%s", out)
 	}
-	rotationDir := filepath.Join(tmp, ".aw", "rotation")
 	if pending, err := loadPendingRotationState(rotationDir, stableID); err != nil {
 		t.Fatal(err)
 	} else if pending != nil {
 		t.Fatalf("pending state retained after definitely-not-applied outcome: %+v", pending)
 	}
-	proposedDID, _ := fixture.snapshot()
-	privatePath, publicPath := pendingRotationKeyPaths(rotationDir, proposedDID)
-	for _, path := range []string{privatePath, publicPath} {
+	var operationKeyPath string
+	select {
+	case operationKeyPath = <-claimedKeyPath:
+	default:
+		t.Fatal("registry fixture did not capture the operation-owned pending key path")
+	}
+	for _, path := range []string{operationKeyPath, awid.PublicKeyPath(operationKeyPath)} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("unused pending key material was not discarded at %s: %v", path, err)
+		}
+	}
+	for _, pattern := range []string{"*.signing.key", "*.signing.pub"} {
+		matches, err := filepath.Glob(filepath.Join(rotationDir, "pending", pattern))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("unused pending key material remains after definitely-not-applied outcome: %v", matches)
 		}
 	}
 }

--- a/cli/go/cmd/aw/id_rotate_key_outcome_test.go
+++ b/cli/go/cmd/aw/id_rotate_key_outcome_test.go
@@ -256,13 +256,21 @@ func TestAwIDRotateKeyPreservesPendingKeyWhenRegistryOutcomeIsUnknown(t *testing
 		t.Fatalf("active key changed to %q after unknown outcome, want old key %q", got, oldDID)
 	}
 
-	// A fresh process must see the same recovery state and must not submit a new rotation.
+	// A fresh process reconciles the preserved operation, reports the result,
+	// and exits without chaining a new key rotation into the same invocation.
 	restartOut, restartErr := runRotateKeyCommand(ctx, bin, tmp)
-	if restartErr == nil {
-		t.Fatalf("expected pending-rotation refusal after restart\n%s", restartOut)
+	if restartErr != nil {
+		t.Fatalf("pending rotation recovery failed: %v\n%s", restartErr, restartOut)
 	}
-	if !strings.Contains(string(restartOut), statePath) {
-		t.Fatalf("restart error missing recovery state path:\n%s", restartOut)
+	for _, want := range []string{"rolled_back", "rerun_required", statePath} {
+		if !strings.Contains(string(restartOut), want) {
+			t.Fatalf("restart recovery output missing %q:\n%s", want, restartOut)
+		}
+	}
+	if pending, err := loadPendingRotationState(rotationDir, stableID); err != nil {
+		t.Fatal(err)
+	} else if pending != nil {
+		t.Fatalf("rolled-back pending state still present: %+v", pending)
 	}
 	_, putCalls := fixture.snapshot()
 	if putCalls != 2 {

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -201,6 +201,10 @@ func recoverPendingRotation(ctx context.Context, identity *awconfig.ResolvedIden
 		out.Detail = fmt.Sprintf("authoritative registry state is unknown; replacement key preserved: %v", err)
 		return out, nil
 	}
+	if err := validateRotationResolutionIdentity(resolution, state.StableID); err != nil {
+		out.Detail = fmt.Sprintf("authoritative registry identity is unknown; replacement key and state preserved: %v", err)
+		return out, nil
+	}
 	switch strings.TrimSpace(resolution.CurrentDIDKey) {
 	case strings.TrimSpace(state.NewDID):
 		if err := finalizePendingRotation(identity, rotationDir, state); err != nil {
@@ -225,6 +229,20 @@ func recoverPendingRotation(ctx context.Context, identity *awconfig.ResolvedIden
 		out.Detail = fmt.Sprintf("registry uses unexpected did:key %s; replacement key and state preserved", strings.TrimSpace(resolution.CurrentDIDKey))
 	}
 	return out, nil
+}
+
+func validateRotationResolutionIdentity(resolution *awid.DidKeyResolution, expectedDIDAW string) error {
+	if resolution == nil {
+		return fmt.Errorf("registry returned no DID resolution")
+	}
+	responseDIDAW := strings.TrimSpace(resolution.DIDAW)
+	if responseDIDAW == "" {
+		return fmt.Errorf("registry resolution is missing did:aw")
+	}
+	if responseDIDAW != strings.TrimSpace(expectedDIDAW) {
+		return fmt.Errorf("registry resolved did:aw %s, expected %s", responseDIDAW, strings.TrimSpace(expectedDIDAW))
+	}
+	return nil
 }
 
 func finalizePendingRotation(identity *awconfig.ResolvedIdentity, rotationDir string, state *pendingRotationState) error {

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/awebai/aw/awconfig"
+	"github.com/awebai/aw/awid"
+	"github.com/spf13/cobra"
+)
+
+type idRotationRecoveryOutput struct {
+	Status        string `json:"status"`
+	OperationID   string `json:"operation_id,omitempty"`
+	StableID      string `json:"stable_id,omitempty"`
+	OldDID        string `json:"old_did,omitempty"`
+	NewDID        string `json:"new_did,omitempty"`
+	RegistryURL   string `json:"registry_url,omitempty"`
+	StatePath     string `json:"state_path,omitempty"`
+	Detail        string `json:"detail,omitempty"`
+	RerunRequired bool   `json:"rerun_required,omitempty"`
+}
+
+var idRotateKeyRecoverCmd = &cobra.Command{
+	Use:   "recover",
+	Short: "Reconcile and safely finish a pending identity key rotation",
+	Args:  cobra.NoArgs,
+	RunE:  runIDRotateKeyRecover,
+}
+
+var idRotateKeyStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Inspect pending identity key rotation state without changing it",
+	Args:  cobra.NoArgs,
+	RunE:  runIDRotateKeyStatus,
+}
+
+func init() {
+	idRotateKeyCmd.AddCommand(idRotateKeyRecoverCmd, idRotateKeyStatusCmd)
+}
+
+func runIDRotateKeyRecover(cmd *cobra.Command, args []string) error {
+	identity, rotationDir, lockPath, err := prepareRotationIdentity(true)
+	if err != nil {
+		return err
+	}
+	transactionLock, err := awconfig.LockExclusive(lockPath)
+	if err != nil {
+		return fmt.Errorf("lock identity key rotation: %w", err)
+	}
+	defer func() { _ = transactionLock.Close() }()
+
+	identity, err = reloadRotationIdentity(identity, rotationDir)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := recoverPendingRotation(ctx, identity, rotationDir)
+	if err != nil {
+		return err
+	}
+	printOutput(out, formatIDRotationRecovery)
+	return nil
+}
+
+func runIDRotateKeyStatus(cmd *cobra.Command, args []string) error {
+	identity, rotationDir, lockPath, err := prepareRotationIdentity(false)
+	if err != nil {
+		return err
+	}
+	// Status is inspection-only: fail immediately rather than queue behind a
+	// mutating rotation whose network request may take tens of seconds.
+	transactionLock, err := awconfig.TryLockExistingExclusive(lockPath)
+	if errors.Is(err, awconfig.ErrLockUnavailable) {
+		printOutput(idRotationRecoveryOutput{
+			Status: "operation_in_progress", StableID: identity.StableID,
+			StatePath: pendingRotationStatePath(rotationDir, identity.StableID),
+			Detail:    "another identity key rotation holds the transaction lock",
+		}, formatIDRotationRecovery)
+		return nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspect identity key rotation lock: %w", err)
+	}
+	if transactionLock != nil {
+		defer func() { _ = transactionLock.Close() }()
+	}
+
+	state, err := loadPendingRotationState(rotationDir, identity.StableID)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		printOutput(idRotationRecoveryOutput{
+			Status: "no_pending", StableID: identity.StableID,
+			StatePath: pendingRotationStatePath(rotationDir, identity.StableID),
+		}, formatIDRotationRecovery)
+		return nil
+	}
+	if err := validatePendingRotationState(rotationDir, identity.StableID, state); err != nil {
+		return fmt.Errorf("invalid pending rotation state: %w", err)
+	}
+	printOutput(rotationRecoveryOutput("pending", rotationDir, state), formatIDRotationRecovery)
+	return nil
+}
+
+func prepareRotationIdentity(requireSigningKey bool) (*awconfig.ResolvedIdentity, string, string, error) {
+	identity, err := resolveIdentity()
+	if err != nil {
+		return nil, "", "", err
+	}
+	if strings.TrimSpace(identity.IdentityScope) != awid.IdentityModeGlobal {
+		return nil, "", "", usageError("this command requires a global identity")
+	}
+	if strings.TrimSpace(identity.Custody) != awid.CustodySelf {
+		return nil, "", "", usageError("this command requires a self-custodial identity")
+	}
+	if strings.TrimSpace(identity.StableID) == "" {
+		return nil, "", "", fmt.Errorf("current identity is missing a did:aw stable identifier")
+	}
+	if requireSigningKey {
+		signingKey, err := resolveIdentitySigningKey(identity)
+		if err != nil {
+			return nil, "", "", err
+		}
+		if err := requirePersistentSelfCustodialIdentity(identity, signingKey); err != nil {
+			return nil, "", "", err
+		}
+	}
+	rotationDir, err := rotationStateDirForIdentity(identity)
+	if err != nil {
+		return nil, "", "", err
+	}
+	lockPath := pendingRotationStatePath(rotationDir, identity.StableID) + ".lock"
+	if err := preflightRotationFile(lockPath); err != nil {
+		return nil, "", "", err
+	}
+	return identity, rotationDir, lockPath, nil
+}
+
+func reloadRotationIdentity(lockIdentity *awconfig.ResolvedIdentity, rotationDir string) (*awconfig.ResolvedIdentity, error) {
+	identity, err := resolveIdentity()
+	if err != nil {
+		return nil, err
+	}
+	currentRotationDir, err := rotationStateDirForIdentity(identity)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(identity.StableID) != strings.TrimSpace(lockIdentity.StableID) || filepath.Clean(currentRotationDir) != filepath.Clean(rotationDir) {
+		return nil, fmt.Errorf("active identity changed while waiting for the rotation lock; retry the command")
+	}
+	signingKey, err := resolveIdentitySigningKey(identity)
+	if err != nil {
+		return nil, err
+	}
+	if err := requirePersistentSelfCustodialIdentity(identity, signingKey); err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+func recoverPendingRotation(ctx context.Context, identity *awconfig.ResolvedIdentity, rotationDir string) (idRotationRecoveryOutput, error) {
+	state, err := loadPendingRotationState(rotationDir, identity.StableID)
+	if err != nil {
+		return idRotationRecoveryOutput{}, err
+	}
+	if state == nil {
+		return idRotationRecoveryOutput{
+			Status: "no_pending", StableID: identity.StableID,
+			StatePath: pendingRotationStatePath(rotationDir, identity.StableID),
+		}, nil
+	}
+	if err := validatePendingRotationState(rotationDir, identity.StableID, state); err != nil {
+		return idRotationRecoveryOutput{}, fmt.Errorf("invalid pending rotation state: %w", err)
+	}
+	out := rotationRecoveryOutput("unknown_preserved", rotationDir, state)
+	registry, err := resolveIdentityRegistryClient(identity)
+	if err != nil {
+		out.Detail = err.Error()
+		return out, nil
+	}
+	registryURL := strings.TrimSpace(state.RegistryURL)
+	if registryURL == "" {
+		registryURL, err = currentIdentityRegistryURL(ctx, identity, registry)
+		if err != nil {
+			out.Detail = err.Error()
+			return out, nil
+		}
+	}
+	out.RegistryURL = registryURL
+	resolution, err := registry.ResolveKeyAt(ctx, registryURL, identity.StableID)
+	if err != nil {
+		out.Detail = fmt.Sprintf("authoritative registry state is unknown; replacement key preserved: %v", err)
+		return out, nil
+	}
+	switch strings.TrimSpace(resolution.CurrentDIDKey) {
+	case strings.TrimSpace(state.NewDID):
+		if err := finalizePendingRotation(identity, rotationDir, state); err != nil {
+			return idRotationRecoveryOutput{}, err
+		}
+		out.Status = "finalized"
+		out.Detail = "registry uses the replacement key; local identity was finalized"
+	case strings.TrimSpace(state.OldDID):
+		if err := cleanupPendingRotationKeypair(state.PendingKey); err != nil {
+			return idRotationRecoveryOutput{}, fmt.Errorf("discard unapplied replacement key for operation %s: %w", state.OperationID, err)
+		}
+		if err := removePendingRotationStateOwned(rotationDir, state.StableID, state.OperationID); err != nil {
+			return idRotationRecoveryOutput{}, fmt.Errorf("remove rolled-back rotation state: %w", err)
+		}
+		out.Status = "rolled_back"
+		out.Detail = "registry still uses the old key; unapplied replacement was discarded"
+	default:
+		out.Detail = fmt.Sprintf("registry uses unexpected did:key %s; replacement key and state preserved", strings.TrimSpace(resolution.CurrentDIDKey))
+	}
+	return out, nil
+}
+
+func finalizePendingRotation(identity *awconfig.ResolvedIdentity, rotationDir string, state *pendingRotationState) error {
+	newSigningKey, alreadyPromoted, err := loadRotationSigningKey(identity.SigningKeyPath, state)
+	if err != nil {
+		return fmt.Errorf("load replacement signing key for operation %s: %w", state.OperationID, err)
+	}
+	if got := awid.ComputeDIDKey(newSigningKey.Public().(ed25519.PublicKey)); strings.TrimSpace(got) != strings.TrimSpace(state.NewDID) {
+		return fmt.Errorf("replacement signing key belongs to %s, not %s", got, state.NewDID)
+	}
+	if !alreadyPromoted {
+		oldSigningKey, err := awid.LoadSigningKey(identity.SigningKeyPath)
+		if err != nil {
+			return err
+		}
+		if got := awid.ComputeDIDKey(oldSigningKey.Public().(ed25519.PublicKey)); strings.TrimSpace(got) != strings.TrimSpace(state.OldDID) {
+			return fmt.Errorf("active signing key %s is neither the old nor replacement key", got)
+		}
+		if err := awid.ArchiveKey(filepath.Dir(identity.SigningKeyPath), state.OldDID, oldSigningKey.Public().(ed25519.PublicKey), oldSigningKey); err != nil {
+			return fmt.Errorf("archive previous signing key: %w", err)
+		}
+		if _, err := promotePendingRotationKeypair(identity.SigningKeyPath, state.PendingKey, state.NewDID); err != nil {
+			return fmt.Errorf("activate replacement signing key: %w", err)
+		}
+	}
+
+	local, err := awconfig.LoadWorktreeIdentityFrom(identity.IdentityPath)
+	if err != nil {
+		return fmt.Errorf("reload local identity state: %w", err)
+	}
+	if strings.TrimSpace(local.StableID) != strings.TrimSpace(state.StableID) {
+		return fmt.Errorf("local identity stable_id changed while finalizing operation %s", state.OperationID)
+	}
+	local.DID = state.NewDID
+	local.RegistryStatus = "registered"
+	if strings.TrimSpace(state.RegistryURL) != "" {
+		local.RegistryURL = state.RegistryURL
+	}
+	if err := awconfig.SaveWorktreeIdentityTo(identity.IdentityPath, local); err != nil {
+		return fmt.Errorf("update local identity state: %w", err)
+	}
+	if err := cleanupPendingRotationKeypair(state.PendingKey); err != nil {
+		return fmt.Errorf("clean pending rotation key material: %w", err)
+	}
+	if err := removePendingRotationStateOwned(rotationDir, state.StableID, state.OperationID); err != nil {
+		return fmt.Errorf("remove finalized rotation state: %w", err)
+	}
+	return nil
+}
+
+func rotationRecoveryOutput(status, rotationDir string, state *pendingRotationState) idRotationRecoveryOutput {
+	return idRotationRecoveryOutput{
+		Status: status, OperationID: state.OperationID, StableID: state.StableID,
+		OldDID: state.OldDID, NewDID: state.NewDID, RegistryURL: state.RegistryURL,
+		StatePath: pendingRotationStatePath(rotationDir, state.StableID),
+	}
+}
+
+func formatIDRotationRecovery(value any) string {
+	out := value.(idRotationRecoveryOutput)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Status:       %s\n", out.Status)
+	if out.OperationID != "" {
+		fmt.Fprintf(&b, "Operation:    %s\n", out.OperationID)
+	}
+	if out.StableID != "" {
+		fmt.Fprintf(&b, "Stable DID:   %s\n", out.StableID)
+	}
+	if out.OldDID != "" {
+		fmt.Fprintf(&b, "Old DID:      %s\n", out.OldDID)
+	}
+	if out.NewDID != "" {
+		fmt.Fprintf(&b, "New DID:      %s\n", out.NewDID)
+	}
+	if out.StatePath != "" {
+		fmt.Fprintf(&b, "State:        %s\n", out.StatePath)
+	}
+	if out.Detail != "" {
+		fmt.Fprintf(&b, "Detail:       %s\n", out.Detail)
+	}
+	if out.RerunRequired {
+		b.WriteString("Next:         rerun `aw id rotate-key` after reviewing this recovery result\n")
+	}
+	return b.String()
+}

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -209,6 +209,10 @@ func recoverPendingRotation(ctx context.Context, identity *awconfig.ResolvedIden
 		out.Status = "finalized"
 		out.Detail = "registry uses the replacement key; local identity was finalized"
 	case strings.TrimSpace(state.OldDID):
+		if safe, detail := localRotationMatchesDID(identity, state.OldDID); !safe {
+			out.Detail = "registry uses the old key, but " + detail + "; replacement key and state preserved"
+			return out, nil
+		}
 		if err := cleanupPendingRotationKeypair(state.PendingKey); err != nil {
 			return idRotationRecoveryOutput{}, fmt.Errorf("discard unapplied replacement key for operation %s: %w", state.OperationID, err)
 		}
@@ -254,6 +258,9 @@ func finalizePendingRotation(identity *awconfig.ResolvedIdentity, rotationDir st
 	if strings.TrimSpace(local.StableID) != strings.TrimSpace(state.StableID) {
 		return fmt.Errorf("local identity stable_id changed while finalizing operation %s", state.OperationID)
 	}
+	if localDID := strings.TrimSpace(local.DID); localDID != strings.TrimSpace(state.OldDID) && localDID != strings.TrimSpace(state.NewDID) {
+		return fmt.Errorf("local identity did:key %s is neither the old nor replacement key", localDID)
+	}
 	local.DID = state.NewDID
 	local.RegistryStatus = "registered"
 	if strings.TrimSpace(state.RegistryURL) != "" {
@@ -269,6 +276,25 @@ func finalizePendingRotation(identity *awconfig.ResolvedIdentity, rotationDir st
 		return fmt.Errorf("remove finalized rotation state: %w", err)
 	}
 	return nil
+}
+
+func localRotationMatchesDID(identity *awconfig.ResolvedIdentity, expectedDID string) (bool, string) {
+	active, err := awid.LoadSigningKey(identity.SigningKeyPath)
+	if err != nil {
+		return false, fmt.Sprintf("the active signing key cannot be read: %v", err)
+	}
+	activeDID := awid.ComputeDIDKey(active.Public().(ed25519.PublicKey))
+	if strings.TrimSpace(activeDID) != strings.TrimSpace(expectedDID) {
+		return false, fmt.Sprintf("the active signing key is %s, not %s", activeDID, expectedDID)
+	}
+	local, err := awconfig.LoadWorktreeIdentityFrom(identity.IdentityPath)
+	if err != nil {
+		return false, fmt.Sprintf("the local identity cannot be read: %v", err)
+	}
+	if strings.TrimSpace(local.DID) != strings.TrimSpace(expectedDID) {
+		return false, fmt.Sprintf("the local identity records %s, not %s", local.DID, expectedDID)
+	}
+	return true, ""
 }
 
 func rotationRecoveryOutput(status, rotationDir string, state *pendingRotationState) idRotationRecoveryOutput {

--- a/cli/go/cmd/aw/id_rotation_recovery.go
+++ b/cli/go/cmd/aw/id_rotation_recovery.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,11 +15,13 @@ import (
 )
 
 type pendingRotationState struct {
+	OperationID string `yaml:"operation_id,omitempty"`
 	StableID    string `yaml:"stable_id"`
 	OldDID      string `yaml:"old_did"`
 	NewDID      string `yaml:"new_did"`
 	RegistryURL string `yaml:"registry_url,omitempty"`
 	PendingKey  string `yaml:"pending_key"`
+	legacy      bool
 }
 
 func rotationStateDirForIdentity(identity *awconfig.ResolvedIdentity) (string, error) {
@@ -60,7 +63,12 @@ func loadPendingRotationState(rotationDir, stableID string) (*pendingRotationSta
 	}
 	var state pendingRotationState
 	if err := yaml.Unmarshal(data, &state); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode pending rotation state %s: %w", path, err)
+	}
+	if strings.TrimSpace(state.OperationID) == "" {
+		state.legacy = true
+		digest := sha256.Sum256([]byte(strings.Join([]string{state.StableID, state.OldDID, state.NewDID, state.PendingKey}, "\x00")))
+		state.OperationID = fmt.Sprintf("legacy-%x", digest[:12])
 	}
 	return &state, nil
 }
@@ -68,6 +76,9 @@ func loadPendingRotationState(rotationDir, stableID string) (*pendingRotationSta
 func savePendingRotationState(rotationDir string, state *pendingRotationState) error {
 	if state == nil {
 		return fmt.Errorf("nil pending rotation state")
+	}
+	if strings.TrimSpace(state.OperationID) == "" {
+		return fmt.Errorf("pending rotation operation_id is required")
 	}
 	data, err := yaml.Marshal(state)
 	if err != nil {
@@ -77,10 +88,25 @@ func savePendingRotationState(rotationDir string, state *pendingRotationState) e
 	if err := preflightRotationFile(path); err != nil {
 		return err
 	}
+	if _, err := os.Lstat(path); err == nil {
+		return fmt.Errorf("pending rotation state already exists at %s", path)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	return awid.AtomicWriteFile(path, data)
 }
 
-func removePendingRotationState(rotationDir, stableID string) error {
+func removePendingRotationStateOwned(rotationDir, stableID, operationID string) error {
+	state, err := loadPendingRotationState(rotationDir, stableID)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return nil
+	}
+	if strings.TrimSpace(state.OperationID) != strings.TrimSpace(operationID) {
+		return fmt.Errorf("pending rotation state is owned by operation %s, not %s", state.OperationID, operationID)
+	}
 	path := pendingRotationStatePath(rotationDir, stableID)
 	if err := preflightRotationFile(path); err != nil {
 		return err
@@ -110,13 +136,89 @@ func preflightRotationFile(path string) error {
 }
 
 func cleanupPendingRotationKeypair(keyPath string) error {
-	if err := os.Remove(keyPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	if err := os.Remove(awid.PublicKeyPath(keyPath)); err != nil && !os.IsNotExist(err) {
-		return err
+	for _, path := range []string{keyPath, awid.PublicKeyPath(keyPath)} {
+		if err := preflightRotationFile(path); err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
 	}
 	return nil
+}
+
+func validatePendingRotationState(rotationDir, stableID string, state *pendingRotationState) error {
+	if state == nil {
+		return fmt.Errorf("missing pending rotation state")
+	}
+	if strings.TrimSpace(state.OperationID) == "" {
+		return fmt.Errorf("pending rotation operation_id is required")
+	}
+	if strings.TrimSpace(state.StableID) != strings.TrimSpace(stableID) {
+		return fmt.Errorf("pending rotation stable_id %q does not match active identity %q", state.StableID, stableID)
+	}
+	if strings.TrimSpace(state.OldDID) == "" || strings.TrimSpace(state.NewDID) == "" || strings.TrimSpace(state.OldDID) == strings.TrimSpace(state.NewDID) {
+		return fmt.Errorf("pending rotation has invalid old_did/new_did")
+	}
+	expectedKey, _ := pendingRotationKeyPaths(rotationDir, state.OperationID)
+	if state.legacy {
+		expectedKey, _ = pendingRotationKeyPaths(rotationDir, state.NewDID)
+	}
+	owned, err := sameRotationPath(state.PendingKey, expectedKey)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return fmt.Errorf("pending rotation key path %q is not owned by operation %s", state.PendingKey, state.OperationID)
+	}
+	if err := preflightRotationFile(state.PendingKey); err != nil {
+		return err
+	}
+	if err := preflightRotationFile(awid.PublicKeyPath(state.PendingKey)); err != nil {
+		return err
+	}
+	priv, err := awid.LoadSigningKey(state.PendingKey)
+	if os.IsNotExist(err) {
+		return nil // Promotion may have moved the private key before state cleanup.
+	}
+	if err != nil {
+		return fmt.Errorf("load pending rotation key: %w", err)
+	}
+	derivedPublic := priv.Public().(ed25519.PublicKey)
+	if got := awid.ComputeDIDKey(derivedPublic); strings.TrimSpace(got) != strings.TrimSpace(state.NewDID) {
+		return fmt.Errorf("pending rotation key belongs to %s, not %s", got, state.NewDID)
+	}
+	storedPublic, err := awid.LoadPublicKey(awid.PublicKeyPath(state.PendingKey))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("load pending rotation public key: %w", err)
+	}
+	if err == nil && !derivedPublic.Equal(storedPublic) {
+		return fmt.Errorf("pending rotation public key does not match its private key")
+	}
+	return nil
+}
+
+func sameRotationPath(first, second string) (bool, error) {
+	resolve := func(path string) (string, error) {
+		parent, err := filepath.EvalSymlinks(filepath.Dir(path))
+		if err != nil {
+			return "", err
+		}
+		absolute, err := filepath.Abs(filepath.Join(parent, filepath.Base(path)))
+		if err != nil {
+			return "", err
+		}
+		return filepath.Clean(absolute), nil
+	}
+	firstResolved, err := resolve(first)
+	if err != nil {
+		return false, err
+	}
+	secondResolved, err := resolve(second)
+	if err != nil {
+		return false, err
+	}
+	return firstResolved == secondResolved, nil
 }
 
 func promotePendingRotationKeypair(activeKeyPath string, pendingKeyPath string, expectedDID string) (string, error) {

--- a/cli/go/cmd/aw/id_rotation_recovery.go
+++ b/cli/go/cmd/aw/id_rotation_recovery.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ed25519"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -178,7 +179,7 @@ func validatePendingRotationState(rotationDir, stableID string, state *pendingRo
 		return err
 	}
 	priv, err := awid.LoadSigningKey(state.PendingKey)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil // Promotion may have moved the private key before state cleanup.
 	}
 	if err != nil {
@@ -189,7 +190,7 @@ func validatePendingRotationState(rotationDir, stableID string, state *pendingRo
 		return fmt.Errorf("pending rotation key belongs to %s, not %s", got, state.NewDID)
 	}
 	storedPublic, err := awid.LoadPublicKey(awid.PublicKeyPath(state.PendingKey))
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("load pending rotation public key: %w", err)
 	}
 	if err == nil && !derivedPublic.Equal(storedPublic) {
@@ -227,7 +228,7 @@ func promotePendingRotationKeypair(activeKeyPath string, pendingKeyPath string, 
 			return "", err
 		}
 		return activeKeyPath, nil
-	} else if err != nil && !os.IsNotExist(err) {
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", err
 	}
 	if err := os.Rename(pendingKeyPath, activeKeyPath); err != nil {
@@ -267,7 +268,7 @@ func loadRotationSigningKey(activeKeyPath string, pending *pendingRotationState)
 	if err == nil {
 		return newPriv, false, nil
 	}
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		return nil, false, fmt.Errorf("load pending rotation key: %w", err)
 	}
 	activePriv, activeErr := awid.LoadSigningKey(activeKeyPath)

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awebai/aw/awconfig"
+	"github.com/awebai/aw/awid"
+)
+
+func TestPendingRotationStateCannotBeOverwrittenOrRemovedByAnotherOperation(t *testing.T) {
+	rotationDir := filepath.Join(t.TempDir(), "rotation")
+	first := &pendingRotationState{
+		OperationID: "11111111-1111-4111-8111-111111111111",
+		StableID:    "did:aw:first",
+		OldDID:      "did:key:old",
+		NewDID:      "did:key:new",
+		PendingKey:  filepath.Join(rotationDir, "pending", "first.signing.key"),
+	}
+	if err := savePendingRotationState(rotationDir, first); err != nil {
+		t.Fatal(err)
+	}
+	second := *first
+	second.OperationID = "22222222-2222-4222-8222-222222222222"
+	if err := savePendingRotationState(rotationDir, &second); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("overwrite error=%v, want existing-operation refusal", err)
+	}
+	if err := removePendingRotationStateOwned(rotationDir, first.StableID, second.OperationID); err == nil || !strings.Contains(err.Error(), "owned by operation") {
+		t.Fatalf("foreign removal error=%v, want ownership refusal", err)
+	}
+	got, err := loadPendingRotationState(rotationDir, first.StableID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.OperationID != first.OperationID {
+		t.Fatalf("pending state after foreign operations=%+v, want first operation", got)
+	}
+}
+
+func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "aw")
+	buildAwBinary(t, ctx, bin)
+
+	for _, tc := range []struct {
+		name          string
+		registryState string
+		wantStatus    string
+		wantPending   bool
+		wantActiveNew bool
+	}{
+		{name: "applied", registryState: "new", wantStatus: "finalized", wantActiveNew: true},
+		{name: "not applied", registryState: "old", wantStatus: "rolled_back"},
+		{name: "unexpected key", registryState: "third", wantStatus: "unknown_preserved", wantPending: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oldPub, oldPriv, err := awid.GenerateKeypair()
+			if err != nil {
+				t.Fatal(err)
+			}
+			newPub, newPriv, err := awid.GenerateKeypair()
+			if err != nil {
+				t.Fatal(err)
+			}
+			thirdPub, _, err := awid.GenerateKeypair()
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldDID := awid.ComputeDIDKey(oldPub)
+			newDID := awid.ComputeDIDKey(newPub)
+			stableID := awid.ComputeStableID(oldPub)
+			current := map[string]string{"old": oldDID, "new": newDID, "third": awid.ComputeDIDKey(thirdPub)}[tc.registryState]
+			fixture := newCLIRotationRegistryFixture(t, stableID, oldDID, func(_ *cliRotationRegistryFixture, w http.ResponseWriter, _ map[string]any) {
+				t.Error("recover submitted a new rotation")
+				http.Error(w, "unexpected", http.StatusInternalServerError)
+			})
+			fixture.currentDID = current
+
+			dir := filepath.Join(tmp, strings.ReplaceAll(tc.name, " ", "-"))
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPriv)
+			operationID := "11111111-1111-4111-8111-111111111111"
+			rotationDir := filepath.Join(dir, ".aw", "rotation")
+			pendingKey, err := savePendingRotationKeypair(rotationDir, operationID, newPub, newPriv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := savePendingRotationState(rotationDir, &pendingRotationState{
+				OperationID: operationID,
+				StableID:    stableID, OldDID: oldDID, NewDID: newDID,
+				RegistryURL: fixture.server.URL, PendingKey: pendingKey,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			out := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")
+			if out.Status != tc.wantStatus {
+				t.Fatalf("recover status=%q, want %q", out.Status, tc.wantStatus)
+			}
+			pending, err := loadPendingRotationState(rotationDir, stableID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (pending != nil) != tc.wantPending {
+				t.Fatalf("pending=%+v, want present=%v", pending, tc.wantPending)
+			}
+			active, err := awid.LoadSigningKey(awconfig.WorktreeSigningKeyPath(dir))
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotActive := awid.ComputeDIDKey(active.Public().(ed25519.PublicKey))
+			wantActive := oldDID
+			if tc.wantActiveNew {
+				wantActive = newDID
+			}
+			if gotActive != wantActive {
+				t.Fatalf("active did=%q, want %q", gotActive, wantActive)
+			}
+			if !tc.wantPending {
+				repeated := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")
+				if repeated.Status != "no_pending" {
+					t.Fatalf("repeated recover status=%q, want no_pending", repeated.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestAwIDRotateKeyWithPendingStateRecoversAndRequiresRerun(t *testing.T) {
+	oldPub, oldPriv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	newPub, newPriv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPub)
+	newDID := awid.ComputeDIDKey(newPub)
+	stableID := awid.ComputeStableID(oldPub)
+	fixture := newCLIRotationRegistryFixture(t, stableID, oldDID, func(_ *cliRotationRegistryFixture, w http.ResponseWriter, _ map[string]any) {
+		t.Error("plain rotate submitted a new operation after recovery")
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	})
+	fixture.currentDID = newDID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "aw")
+	buildAwBinary(t, ctx, bin)
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPriv)
+	operationID := "11111111-1111-4111-8111-111111111111"
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	pendingKey, err := savePendingRotationKeypair(rotationDir, operationID, newPub, newPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := savePendingRotationState(rotationDir, &pendingRotationState{
+		OperationID: operationID, StableID: stableID, OldDID: oldDID, NewDID: newDID,
+		RegistryURL: fixture.server.URL, PendingKey: pendingKey,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := runRotationRecoveryCommand(t, ctx, bin, dir)
+	if out.Status != "finalized" || !out.RerunRequired {
+		t.Fatalf("plain rotate recovery=%+v, want finalized with rerun required", out)
+	}
+	if _, calls := fixture.snapshot(); calls != 0 {
+		t.Fatalf("rotation PUT calls=%d, want 0", calls)
+	}
+}
+
+func TestAwIDRotateKeyStatusIsReadOnlyAndDistinguishesActiveOperation(t *testing.T) {
+	oldPub, oldPriv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPub)
+	stableID := awid.ComputeStableID(oldPub)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "aw")
+	buildAwBinary(t, ctx, bin)
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, "https://registry.invalid", oldPriv)
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	lockPath := pendingRotationStatePath(rotationDir, stableID) + ".lock"
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("fresh rotation lock unexpectedly exists: %v", err)
+	}
+	out := runRotationRecoveryCommand(t, ctx, bin, dir, "status")
+	if out.Status != "no_pending" {
+		t.Fatalf("fresh status=%q, want no_pending", out.Status)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("read-only status created a lock file: %v", err)
+	}
+
+	lock, err := awconfig.LockExclusive(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Leave enough budget for process startup under the package's parallel CLI
+	// tests; a blocking lock mutation still times out because the holder is only
+	// released after this subprocess returns.
+	statusCtx, statusCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer statusCancel()
+	out = runRotationRecoveryCommand(t, statusCtx, bin, dir, "status")
+	if out.Status != "operation_in_progress" {
+		t.Fatalf("locked status=%q, want operation_in_progress", out.Status)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out = runRotationRecoveryCommand(t, ctx, bin, dir, "status")
+	if out.Status != "no_pending" {
+		t.Fatalf("unlocked status=%q, want no_pending", out.Status)
+	}
+}
+
+func TestAwIDRotateKeyStatusRejectsCorruptStateWithoutChangingIt(t *testing.T) {
+	oldPub, oldPriv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPub)
+	stableID := awid.ComputeStableID(oldPub)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "aw")
+	buildAwBinary(t, ctx, bin)
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, "https://registry.invalid", oldPriv)
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	statePath := pendingRotationStatePath(rotationDir, stableID)
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := []byte("operation_id: [partial")
+	if err := os.WriteFile(statePath, corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "status", "--json")
+	cmd.Env = testCommandEnv(dir)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err == nil || !strings.Contains(string(out), "decode pending rotation state") {
+		t.Fatalf("corrupt-state status error=%v\n%s", err, out)
+	}
+	got, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(corrupt) {
+		t.Fatalf("status changed corrupt state: %q", got)
+	}
+}
+
+func runRotationRecoveryCommand(t *testing.T, ctx context.Context, bin, dir string, action ...string) idRotationRecoveryOutput {
+	t.Helper()
+	args := []string{"id", "rotate-key"}
+	args = append(args, action...)
+	args = append(args, "--json")
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = testCommandEnv(dir)
+	cmd.Dir = dir
+	data, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("aw %s failed: %v\n%s", strings.Join(args, " "), err, data)
+	}
+	var out idRotationRecoveryOutput
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode recovery output: %v\n%s", err, data)
+	}
+	return out
+}

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/awebai/aw/awconfig"
 	"github.com/awebai/aw/awid"
+	"gopkg.in/yaml.v3"
 )
 
 func TestPendingRotationStateCannotBeOverwrittenOrRemovedByAnotherOperation(t *testing.T) {
@@ -45,6 +46,38 @@ func TestPendingRotationStateCannotBeOverwrittenOrRemovedByAnotherOperation(t *t
 	}
 }
 
+func TestLegacyPendingRotationStateGetsStableOwnershipForRecovery(t *testing.T) {
+	rotationDir := filepath.Join(t.TempDir(), "rotation")
+	legacy := &pendingRotationState{
+		StableID: "did:aw:legacy", OldDID: "did:key:old", NewDID: "did:key:new",
+		PendingKey: filepath.Join(rotationDir, "pending", pendingFileBase("did:key:new")+".signing.key"),
+	}
+	data, err := yaml.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statePath := pendingRotationStatePath(rotationDir, legacy.StableID)
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadPendingRotationState(rotationDir, legacy.StableID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil || !loaded.legacy || !strings.HasPrefix(loaded.OperationID, "legacy-") {
+		t.Fatalf("legacy ownership was not derived: %+v", loaded)
+	}
+	if err := removePendingRotationStateOwned(rotationDir, legacy.StableID, loaded.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("legacy state still exists after owned removal: %v", err)
+	}
+}
+
 func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
@@ -58,9 +91,11 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 		wantStatus    string
 		wantPending   bool
 		wantActiveNew bool
+		localPromoted bool
 	}{
 		{name: "applied", registryState: "new", wantStatus: "finalized", wantActiveNew: true},
 		{name: "not applied", registryState: "old", wantStatus: "rolled_back"},
+		{name: "old registry with promoted local key", registryState: "old", wantStatus: "unknown_preserved", wantPending: true, wantActiveNew: true, localPromoted: true},
 		{name: "unexpected key", registryState: "third", wantStatus: "unknown_preserved", wantPending: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -103,6 +138,16 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 				RegistryURL: fixture.server.URL, PendingKey: pendingKey,
 			}); err != nil {
 				t.Fatal(err)
+			}
+			if tc.localPromoted {
+				if _, err := promotePendingRotationKeypair(awconfig.WorktreeSigningKeyPath(dir), pendingKey, newDID); err != nil {
+					t.Fatal(err)
+				}
+				local := loadIdentityForTest(t, dir)
+				local.DID = newDID
+				if err := awconfig.SaveWorktreeIdentityTo(filepath.Join(dir, ".aw", "identity.yaml"), local); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			out := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -78,6 +78,27 @@ func TestLegacyPendingRotationStateGetsStableOwnershipForRecovery(t *testing.T) 
 	}
 }
 
+func TestRotationResolutionIdentityMustBePresentAndMatch(t *testing.T) {
+	stableID := "did:aw:expected"
+	for _, tc := range []struct {
+		name       string
+		resolution *awid.DidKeyResolution
+		wantError  bool
+	}{
+		{name: "nil", wantError: true},
+		{name: "empty", resolution: &awid.DidKeyResolution{}, wantError: true},
+		{name: "mismatched", resolution: &awid.DidKeyResolution{DIDAW: "did:aw:other"}, wantError: true},
+		{name: "matching", resolution: &awid.DidKeyResolution{DIDAW: stableID}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRotationResolutionIdentity(tc.resolution, stableID)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("validation error=%v, want error=%v", err, tc.wantError)
+			}
+		})
+	}
+}
+
 func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
@@ -85,16 +106,24 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 	bin := filepath.Join(tmp, "aw")
 	buildAwBinary(t, ctx, bin)
 
+	wrongDIDAW := "did:aw:other-identity"
+	emptyDIDAW := ""
 	for _, tc := range []struct {
-		name          string
-		registryState string
-		wantStatus    string
-		wantPending   bool
-		wantActiveNew bool
-		localPromoted bool
+		name                string
+		registryState       string
+		responseDIDAW       *string
+		overrideResponseDID bool
+		wantStatus          string
+		wantPending         bool
+		wantActiveNew       bool
+		localPromoted       bool
 	}{
 		{name: "applied", registryState: "new", wantStatus: "finalized", wantActiveNew: true},
 		{name: "not applied", registryState: "old", wantStatus: "rolled_back"},
+		{name: "old key from another identity", registryState: "old", responseDIDAW: &wrongDIDAW, overrideResponseDID: true, wantStatus: "unknown_preserved", wantPending: true},
+		{name: "new key from another identity", registryState: "new", responseDIDAW: &wrongDIDAW, overrideResponseDID: true, wantStatus: "unknown_preserved", wantPending: true},
+		{name: "empty response identity", registryState: "new", responseDIDAW: &emptyDIDAW, overrideResponseDID: true, wantStatus: "unknown_preserved", wantPending: true},
+		{name: "missing response identity", registryState: "old", overrideResponseDID: true, wantStatus: "unknown_preserved", wantPending: true},
 		{name: "old registry with promoted local key", registryState: "old", wantStatus: "unknown_preserved", wantPending: true, wantActiveNew: true, localPromoted: true},
 		{name: "unexpected key", registryState: "third", wantStatus: "unknown_preserved", wantPending: true},
 	} {
@@ -120,6 +149,9 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 				http.Error(w, "unexpected", http.StatusInternalServerError)
 			})
 			fixture.currentDID = current
+			if tc.overrideResponseDID {
+				fixture.responseDIDAW = tc.responseDIDAW
+			}
 
 			dir := filepath.Join(tmp, strings.ReplaceAll(tc.name, " ", "-"))
 			if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -193,6 +193,15 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 			if (pending != nil) != tc.wantPending {
 				t.Fatalf("pending=%+v, want present=%v", pending, tc.wantPending)
 			}
+			// A promoted operation owns its replacement at the active path. Every
+			// other preserved operation must retain both operation-owned key files.
+			if tc.wantPending && !tc.localPromoted {
+				for _, path := range []string{pending.PendingKey, awid.PublicKeyPath(pending.PendingKey)} {
+					if _, err := os.Stat(path); err != nil {
+						t.Fatalf("preserved operation key missing at %s: %v", path, err)
+					}
+				}
+			}
 			active, err := awid.LoadSigningKey(awconfig.WorktreeSigningKeyPath(dir))
 			if err != nil {
 				t.Fatal(err)

--- a/cli/go/cmd/aw/identity_home_dynamic_path_test.go
+++ b/cli/go/cmd/aw/identity_home_dynamic_path_test.go
@@ -85,7 +85,7 @@ func TestExternalIdentityRotationRecoveryPathsFailClosedAtEachUse(t *testing.T) 
 	if err := os.Symlink(outside, filepath.Join(rotationDir, "pending")); err != nil {
 		t.Fatal(err)
 	}
-	state := &pendingRotationState{StableID: "did:aw:stable", PendingKey: "pending.key"}
+	state := &pendingRotationState{OperationID: "11111111-1111-4111-8111-111111111111", StableID: "did:aw:stable", PendingKey: "pending.key"}
 	if err := savePendingRotationState(rotationDir, state); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("pending-state write symlink error=%v", err)
 	}

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -539,8 +539,30 @@ Flags:
 
 Rotate the current global identity signing key at the registry
 
+Subcommands:
+- `recover` Reconcile and safely finish a pending identity key rotation
+- `status` Inspect pending identity key rotation state without changing it
+
 Flags:
 - `-h, --help help for rotate-key`
+
+## `id rotate-key recover`
+
+### `id rotate-key recover`
+
+Reconcile and safely finish a pending identity key rotation
+
+Flags:
+- `-h, --help help for recover`
+
+## `id rotate-key status`
+
+### `id rotate-key status`
+
+Inspect pending identity key rotation state without changing it
+
+Flags:
+- `-h, --help help for status`
 
 ## `id show`
 


### PR DESCRIPTION
Review candidate at exact SHA ead5f32b36fc9142a0cd640ef45055690a7e3da7, under independent review by aw-sec-rev-9. Opened by the coordinator so hosted CI runs in parallel with review rather than being discovered absent at the merge gate.

Closes the half of `aajc.12` that locking (`.12a`, merged as 5e722791) did not cover.

**The defect:** one process could delete another operation's rotation state. Concretely — A commits at the registry but loses the response; B owns the overwritten pending state, receives *definitely-not-applied*, and deletes the shared state. The registry now uses A's key, A's pending key is orphaned with no recovery record, and the local active key is stale. That defeats the committed-response-loss key-survival invariant `aajc.1` established.

Second defect: `id_rotation_recovery.go` held a reconciliation primitive with **no production caller**, so a stuck pending state meant permanent rotation deadlock with no supported way out.

**Design decisions, recorded because they are not obvious:**
- Plain `rotate-key` meeting pending state **recovers, reports, and requires a rerun** rather than chaining into a fresh rotation. This is key material; chaining means a subtly wrong recovery compounds into new key generation before any human looks.
- `status` is **read-only** and separate. Inspection must never require mutation — an operator facing a stuck rotation needs to see the state before deciding to change it.
- **Unknown is never treated as not-applied.** Preserve the key and report.

Seven named production mutations red. Full `go test ./...` and `-race` pass; Windows cross-compile passes.

Author additionally found and fixed a case during self-review: registry-old cannot trigger rollback when local identity and active key already show the replacement — that now preserves *unknown* rather than destroying a key for a rotation that actually succeeded.