### PR TITLE
default-aaku: make remote signature decoding fail before verification

### DIFF
--- a/channel-core/src/identity/certificate.ts
+++ b/channel-core/src/identity/certificate.ts
@@ -32,5 +32,7 @@ export async function loadTeamCertificate(path: string): Promise<TeamCertificate
 }
 
 export function encodeTeamCertificateHeader(cert: TeamCertificate): string {
+  // This transport envelope deliberately uses padded standard base64. The Go
+  // header decoder must use StdEncoding so certificates emitted here round-trip.
   return Buffer.from(JSON.stringify(cert), "utf-8").toString("base64");
 }

--- a/channel-core/src/identity/keys.ts
+++ b/channel-core/src/identity/keys.ts
@@ -11,6 +11,9 @@ export async function loadSigningKey(path: string): Promise<Uint8Array> {
     throw new Error(`no ED25519 PRIVATE KEY PEM block in ${path}`);
   }
 
+  // Local key material follows the PEM file format, which is padded and
+  // line-wrapped by definition. Do not route this through the remote-signature
+  // raw-base64 decoder; the exact 32-byte seed check below remains fail-closed.
   const b64 = match[1].replace(/\s/g, "");
   const bin = atob(b64);
   const bytes = new Uint8Array(bin.length);

--- a/channel-core/src/identity/registry.ts
+++ b/channel-core/src/identity/registry.ts
@@ -4,7 +4,7 @@ import { sha256, sha512 } from "@noble/hashes/sha2.js";
 import * as ed from "@noble/ed25519";
 import { getDomain } from "tldts";
 import { computeStableID, extractPublicKey } from "./did.js";
-import { decodeRawStdBase64OrEmpty } from "./base64.js";
+import { decodeRawStdBase64 } from "./base64.js";
 
 ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
 
@@ -784,9 +784,10 @@ function isCanonicalTimestamp(value: string): boolean {
 }
 
 function b64Decode(value: string): Uint8Array {
-  // Strict, matching Go's RawStdEncoding: a signature the Go verifier refuses
-  // must not decode here (default-aajc.8).
-  return decodeRawStdBase64OrEmpty(value);
+  // DID-log heads are remote signed data. Throw on malformed raw base64 before
+  // ed.verify so rejection does not depend on how the verifier treats an empty
+  // signature.
+  return decodeRawStdBase64(value);
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/channel-core/src/identity/signing.ts
+++ b/channel-core/src/identity/signing.ts
@@ -136,7 +136,9 @@ export async function signMessage(
  * Verify a message envelope signature.
  * Returns 'unverified' if DID or signature is missing.
  * Returns 'failed' if signature doesn't verify.
- * Returns 'verified' if valid.
+ * Returns 'verified' if the signature is valid. This does not prove that the
+ * signer owns the claimed sender address; every inbound path must pass the
+ * result through SenderTrustManager.normalizeTrust for that binding decision.
  */
 export async function verifyMessage(
   env: MessageEnvelope,

--- a/channel-core/src/identity/trust.ts
+++ b/channel-core/src/identity/trust.ts
@@ -5,7 +5,7 @@ import type { VerificationStatus } from "./signing.js";
 import { extractPublicKey } from "./did.js";
 import { RegistryResolver, isValidDidLogSequence, type VerifiedLogHead } from "./registry.js";
 import { PinStore, type IdentityScope } from "./pinstore.js";
-import { decodeRawStdBase64OrEmpty } from "./base64.js";
+import { decodeRawStdBase64 } from "./base64.js";
 
 ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
 
@@ -609,9 +609,10 @@ function canonicalObject(fields: Array<[string, string]>): string {
 }
 
 function b64Decode(value: string): Uint8Array {
-  // Strict, matching Go's RawStdEncoding: a signature the Go verifier refuses
-  // must not decode here (default-aajc.8).
-  return decodeRawStdBase64OrEmpty(value);
+  // Rotation and replacement announcements are remote signed data. Throw on
+  // malformed raw base64 before ed.verify so rejection does not depend on how
+  // the verifier treats an empty signature.
+  return decodeRawStdBase64(value);
 }
 
 function escapeJSON(s: string): string {

--- a/channel-core/test/registry.test.ts
+++ b/channel-core/test/registry.test.ts
@@ -13,6 +13,19 @@ import {
   type DidKeyResolution,
 } from "../src/identity/registry.js";
 
+// Delegate to the real verifier while observing whether malformed input reaches it.
+const verifyCalls = vi.hoisted(() => vi.fn());
+vi.mock("@noble/ed25519", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@noble/ed25519")>();
+  return {
+    ...actual,
+    verify: (...args: Parameters<typeof actual.verify>) => {
+      verifyCalls();
+      return actual.verify(...args);
+    },
+  };
+});
+
 const testDir = dirname(fileURLToPath(import.meta.url));
 const dnsVectors = JSON.parse(
   readFileSync(join(testDir, "..", "..", "docs", "vectors", "dns-txt-v1.json"), "utf-8"),
@@ -159,6 +172,23 @@ describe("registry verification", () => {
     const result = verifyDidKeyResolution(resolution, undefined, Date.now());
     expect(result.outcome).toBe("OK_VERIFIED");
     expect(result.nextHead?.entryHash).toBe(register!.entry_hash);
+  });
+
+  test("rejects malformed log-head signatures before invoking the verifier", () => {
+    const register = identityLogVectors.entries.find((entry) => entry.name === "register_did")!;
+    const resolution: DidKeyResolution = {
+      did_aw: identityLogVectors.mapping.did_aw,
+      current_did_key: identityLogVectors.mapping.initial_did_key,
+      log_head: {
+        ...register.entry_payload,
+        entry_hash: register.entry_hash,
+        signature: "YWJj=",
+      },
+    };
+
+    verifyCalls.mockClear();
+    expect(verifyDidKeyResolution(resolution, undefined, Date.now()).outcome).toBe("HARD_ERROR");
+    expect(verifyCalls).not.toHaveBeenCalled();
   });
 
   test("degrades when log_head is missing", () => {

--- a/channel-core/test/trust.test.ts
+++ b/channel-core/test/trust.test.ts
@@ -15,6 +15,19 @@ import {
   type RotationAnnouncement,
 } from "../src/index.js";
 
+// Delegate to the real verifier while observing whether malformed input reaches it.
+const verifyCalls = vi.hoisted(() => vi.fn());
+vi.mock("@noble/ed25519", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@noble/ed25519")>();
+  return {
+    ...actual,
+    verify: (...args: Parameters<typeof actual.verify>) => {
+      verifyCalls();
+      return actual.verify(...args);
+    },
+  };
+});
+
 ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
 
 function seed(byte: number): Uint8Array {
@@ -197,6 +210,48 @@ describe("SenderTrustManager", () => {
     const result = await trust.normalizeTrust(store, "verified", "alice", did, undefined, undefined);
     expect(result.status).toBe("verified");
     expect(store.addresses.get("backend:acme.com/alice")).toBe(did);
+  });
+
+  test("rejects malformed announcement signatures before invoking the verifier", async () => {
+    const oldIdentity = await didFromSeed(41);
+    const newIdentity = await didFromSeed(42);
+    const controller = await didFromSeed(43);
+    const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    const trust = new SenderTrustManager(
+      {} as never,
+      {} as never,
+      "backend:acme.com",
+      "",
+    ) as unknown as {
+      verifyRotationAnnouncement(
+        announcement: RotationAnnouncement,
+        messageDID: string,
+        pinnedDID: string,
+      ): boolean;
+      verifyReplacementAnnouncement(
+        address: string,
+        announcement: ReplacementAnnouncement,
+        messageDID: string,
+        pinnedDID: string,
+        meta: { controllerDid?: string },
+      ): boolean;
+    };
+    verifyCalls.mockClear();
+    expect(trust.verifyRotationAnnouncement({
+      old_did: oldIdentity.did,
+      new_did: newIdentity.did,
+      timestamp,
+      old_key_signature: "YWJj=",
+    }, newIdentity.did, oldIdentity.did)).toBe(false);
+    expect(trust.verifyReplacementAnnouncement("acme.com/alice", {
+      address: "acme.com/alice",
+      old_did: oldIdentity.did,
+      new_did: newIdentity.did,
+      controller_did: controller.did,
+      timestamp,
+      controller_signature: "YWJj=",
+    }, newIdentity.did, oldIdentity.did, { controllerDid: controller.did })).toBe(false);
+    expect(verifyCalls).not.toHaveBeenCalled();
   });
 
   test("accepts valid rotation announcements", async () => {

--- a/cli/go/awid/certificate.go
+++ b/cli/go/awid/certificate.go
@@ -189,7 +189,9 @@ func EncodeTeamCertificateHeader(cert *TeamCertificate) (string, error) {
 }
 
 // DecodeTeamCertificateHeader decodes a certificate from the
-// X-AWID-Team-Certificate HTTP header.
+// X-AWID-Team-Certificate HTTP header. This transport envelope deliberately
+// uses padded StdEncoding to round-trip headers emitted by TypeScript's
+// encodeTeamCertificateHeader; RawStdEncoding would reject those headers.
 func DecodeTeamCertificateHeader(encoded string) (*TeamCertificate, error) {
 	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {

--- a/cli/go/awid/signing.go
+++ b/cli/go/awid/signing.go
@@ -266,8 +266,9 @@ func SignArbitraryPayload(key ed25519.PrivateKey, payload map[string]any, timest
 // Returns Unverified if DID or signature is missing (legacy message).
 // Returns Failed if the DID is malformed, the signature doesn't verify,
 // or SigningKeyID disagrees with FromDID.
-// Returns Verified if the signature is valid.
-// Does not check TOFU pins or custody — callers handle those.
+// Returns Verified if the signature is valid. Verified does not prove that
+// FromDID owns the claimed sender address; every inbound path must pass the
+// result through Client.NormalizeSenderTrust for that binding decision.
 func VerifyMessage(env *MessageEnvelope) (VerificationStatus, error) {
 	if env.FromDID == "" || env.Signature == "" {
 		return Unverified, nil

--- a/cli/go/chat/chat.go
+++ b/cli/go/chat/chat.go
@@ -311,6 +311,9 @@ func decryptChatEvent(client *awid.Client, ev *Event) error {
 		return err
 	}
 	ev.Body = plain.Body
+	// Verified means the encrypted-envelope signature is valid, not that the
+	// signer owns the claimed address. The inbound caller must immediately pass
+	// this result through Client.NormalizeSenderTrust.
 	ev.VerificationStatus = awid.Verified
 	return nil
 }

--- a/docs/vectors/README.md
+++ b/docs/vectors/README.md
@@ -79,6 +79,22 @@ These vectors exist to prevent subtle cross-language drift (Python ↔ Go) in:
 - **Canonical JSON:** lexicographic key sort, compact separators, literal UTF-8 (no `\uXXXX` escapes).
 - **Signatures:** Ed25519 signature bytes encoded as base64 (RFC 4648), no `=` padding.
 
+### Base64 decoder-site classification
+
+Decoder strictness follows the producer and field format; it is not a global
+consistency sweep.
+
+| Class | Production sites | Required behavior and reason |
+| --- | --- | --- |
+| Remote signatures | TypeScript `identity/signing.ts` (message envelopes), `identity/trust.ts` (rotation/replacement announcements), and `identity/registry.ts` (DID-log heads); Go `awid/{signing,rotate,a2a_publication,certificate,e2ee_keys,e2ee_messages,atomic_address_claim,stable_identity}.go` signature decodes | Use raw standard base64 without padding, with Go/TypeScript acceptance parity. TypeScript throws on malformed input before calling Ed25519 verification, so rejection does not depend on the verifier's treatment of an empty signature. Aligning mechanisms within this class is required. |
+| E2EE binary protocol fields | Go `awid/e2ee_keys.go`, `awid/e2ee_messages.go`, and `cmd/aw/id_encryption_key.go` public-key, ciphertext, nonce, encapsulated-key, and wrapped-key decodes | Use raw standard base64 because the E2EE wire contract defines those fields that way. These are protocol bytes, not signature-verdict sites. |
+| Team-certificate transport envelope | TypeScript `identity/certificate.ts` encoder and Go `awid/certificate.go` header encoder/decoder | Use padded standard base64. TypeScript emits padding and has no header decoder; changing Go to raw decoding would reject every TypeScript-produced certificate header and break authentication. |
+| Local private-key material | TypeScript `identity/keys.ts` PEM loader and Go `cmd/aw/init_apikey.go` partial-init state | Follow the file format: PEM is padded and line-wrapped, while the Go partial-init state is written and read with padded standard base64. Both paths validate the decoded key size and identity binding. Remote-signature strictness does not apply to local key files. |
+
+The important boundary is the class: make remote-signature decoders agree with
+one another, but do not flatten transport envelopes or local key formats into
+that rule.
+
 ## Validation
 
 The backend test suite validates these vectors:


### PR DESCRIPTION
## Summary
- use throwing raw-standard-base64 decoding for rotation, replacement, and DID-log signatures
- prove malformed signatures never reach the real Ed25519 verifier
- classify remote signatures, protocol bytes, certificate transport, and local key formats; clarify signature validity is not address ownership

## Mutation evidence
- trust decoder changed back to OrEmpty: announcement guard RED (2 verifier calls), registry guard GREEN
- registry decoder changed back to OrEmpty: log-head guard RED (1 verifier call), announcement guard GREEN

## Validation
- `channel-core`: 218 Vitest + 1 compiled process test; production audit 0
- `cli/go`: `go test ./...` green
- Claude Channel: build/provenance/package + 19 tests
- Pi: build/provenance/package + 13 tests

Exact candidate: `98587cdee5bc18e95a4bce992dcc739e725444c4`