### PR TITLE
default-aamt: SIGKILL DID rotation crash matrix

### DIFF
--- a/cli/go/awid/atomic.go
+++ b/cli/go/awid/atomic.go
@@ -3,6 +3,8 @@ package awid
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/awebai/aw/internal/crashtest"
 )
 
 // atomicWriteFile writes data to path using temp-file-and-rename
@@ -20,6 +22,14 @@ func AtomicWriteFile(path string, data []byte) error {
 // atomicWriteFileMode writes data to path using temp-file-and-rename.
 // The temp file is chmod'd to mode before any data is written.
 func atomicWriteFileMode(path string, data []byte, mode os.FileMode) error {
+	return atomicWriteFileModeAtCheckpoint(path, data, mode, "")
+}
+
+func atomicWritePrivateKeyFile(path string, data []byte) error {
+	return atomicWriteFileModeAtCheckpoint(path, data, 0o600, "after-private-key-temp-sync")
+}
+
+func atomicWriteFileModeAtCheckpoint(path string, data []byte, mode os.FileMode, checkpoint string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
@@ -46,6 +56,10 @@ func atomicWriteFileMode(path string, data []byte, mode os.FileMode) error {
 	}
 	if err := tmp.Close(); err != nil {
 		return err
+	}
+	if checkpoint != "" {
+		// Crash-test observation only; the synced secret temp is not yet renamed.
+		crashtest.Checkpoint(checkpoint, path)
 	}
 
 	return os.Rename(tmpName, path)

--- a/cli/go/awid/keys.go
+++ b/cli/go/awid/keys.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/awebai/aw/internal/crashtest"
 	"github.com/awebai/aw/internal/pathpreflight"
 )
 
@@ -35,7 +36,13 @@ func SaveKeypairAt(keyPath, pubPath string, pub ed25519.PublicKey, priv ed25519.
 	if err := writePrivateKey(keyPath, priv); err != nil {
 		return err
 	}
-	return writePublicKey(pubPath, pub)
+	// Crash-test observation only; inert without the inherited pipe capability.
+	crashtest.Checkpoint("after-keypair-private-commit", keyPath)
+	if err := writePublicKey(pubPath, pub); err != nil {
+		return err
+	}
+	crashtest.Checkpoint("after-keypair-public-commit", pubPath)
+	return nil
 }
 
 // SaveSigningKey writes only the private signing key PEM to the given path.
@@ -136,7 +143,13 @@ func ArchiveKey(keysDir, oldDID string, pub ed25519.PublicKey, priv ed25519.Priv
 	if err := writePrivateKey(keyPath, priv); err != nil {
 		return err
 	}
-	return writePublicKey(pubPath, pub)
+	// Crash-test observation only; archive files form a separate durable pair.
+	crashtest.Checkpoint("after-keypair-private-commit", keyPath)
+	if err := writePublicKey(pubPath, pub); err != nil {
+		return err
+	}
+	crashtest.Checkpoint("after-keypair-public-commit", pubPath)
+	return nil
 }
 
 func writePrivateKey(path string, priv ed25519.PrivateKey) error {

--- a/cli/go/awid/keys.go
+++ b/cli/go/awid/keys.go
@@ -157,7 +157,7 @@ func writePrivateKey(path string, priv ed25519.PrivateKey) error {
 		Type:  "ED25519 PRIVATE KEY",
 		Bytes: priv.Seed(),
 	})
-	if err := atomicWriteFile(path, data); err != nil {
+	if err := atomicWritePrivateKeyFile(path, data); err != nil {
 		return fmt.Errorf("write private key %s: %w", path, err)
 	}
 	return nil

--- a/cli/go/cmd/aw/id_rotate_key.go
+++ b/cli/go/cmd/aw/id_rotate_key.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/awebai/aw/awconfig"
 	"github.com/awebai/aw/awid"
+	"github.com/awebai/aw/internal/crashtest"
 	"github.com/spf13/cobra"
 )
 
@@ -94,6 +95,8 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Crash-test observation only; inert without the inherited pipe capability.
+	crashtest.Checkpoint("after-key-generation")
 	oldDID := strings.TrimSpace(identity.DID)
 	newDID := awid.ComputeDIDKey(newPub)
 	if oldDID == newDID {
@@ -115,6 +118,8 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	if err := savePendingRotationState(rotationDir, pendingState); err != nil {
 		return err
 	}
+	// Crash-test observation only; the state rename is now visible to recovery.
+	crashtest.Checkpoint("after-pending-state-commit")
 	if _, err := savePendingRotationKeypair(rotationDir, operationID, newPub, newPriv); err != nil {
 		_ = cleanupPendingRotationKeypair(pendingKeyPath)
 		_ = removePendingRotationStateOwned(rotationDir, identity.StableID, operationID)
@@ -159,7 +164,6 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 			nil,
 		)
 	}
-
 	if err := finalizePendingRotation(identity, rotationDir, pendingState); err != nil {
 		return rotationFinalizeError(rotationDir, identity.StableID, "failed to finalize the applied rotation", err)
 	}

--- a/cli/go/cmd/aw/id_rotate_key.go
+++ b/cli/go/cmd/aw/id_rotate_key.go
@@ -26,23 +26,11 @@ func init() {
 }
 
 func runIDRotateKey(cmd *cobra.Command, args []string) error {
-	lockIdentity, err := resolveIdentity()
+	// A crash may have promoted the private key before identity.yaml. Resolve
+	// only the stable transaction scope until pending recovery has had a chance
+	// to reconcile that intentionally split state under the lock.
+	lockIdentity, rotationDir, lockPath, err := prepareRotationIdentity(false)
 	if err != nil {
-		return err
-	}
-	lockSigningKey, err := resolveIdentitySigningKey(lockIdentity)
-	if err != nil {
-		return err
-	}
-	if err := requirePersistentSelfCustodialIdentity(lockIdentity, lockSigningKey); err != nil {
-		return err
-	}
-	rotationDir, err := rotationStateDirForIdentity(lockIdentity)
-	if err != nil {
-		return err
-	}
-	lockPath := pendingRotationStatePath(rotationDir, lockIdentity.StableID) + ".lock"
-	if err := preflightRotationFile(lockPath); err != nil {
 		return err
 	}
 	transactionLock, err := awconfig.LockExclusive(lockPath)
@@ -57,7 +45,7 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	// A preceding lock holder may have completed a rotation while this process
 	// waited. Reload both the identity and its signing key inside the transaction
 	// so a waiter cannot create recovery state from the retired key.
-	identity, err := resolveIdentity()
+	identity, err := resolveRotationIdentity()
 	if err != nil {
 		return err
 	}
@@ -67,13 +55,6 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	}
 	if strings.TrimSpace(identity.StableID) != strings.TrimSpace(lockIdentity.StableID) || filepath.Clean(currentRotationDir) != filepath.Clean(rotationDir) {
 		return fmt.Errorf("active identity changed while waiting for the rotation lock; retry the rotation")
-	}
-	signingKey, err := resolveIdentitySigningKey(identity)
-	if err != nil {
-		return err
-	}
-	if err := requirePersistentSelfCustodialIdentity(identity, signingKey); err != nil {
-		return err
 	}
 	if pending, err := loadPendingRotationState(rotationDir, identity.StableID); err != nil {
 		return err
@@ -85,6 +66,13 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 		out.RerunRequired = true
 		printOutput(out, formatIDRotationRecovery)
 		return nil
+	}
+	signingKey, err := resolveIdentitySigningKey(identity)
+	if err != nil {
+		return err
+	}
+	if err := requirePersistentSelfCustodialIdentity(identity, signingKey); err != nil {
+		return err
 	}
 	registry, err := resolveIdentityRegistryClient(identity)
 	if err != nil {

--- a/cli/go/cmd/aw/id_rotate_key.go
+++ b/cli/go/cmd/aw/id_rotate_key.go
@@ -124,7 +124,7 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	// Crash-test observation only; the state rename is now visible to recovery.
 	crashtest.Checkpoint("after-pending-state-commit")
 	if _, err := savePendingRotationKeypair(rotationDir, operationID, newPub, newPriv); err != nil {
-		_ = cleanupPendingRotationKeypair(pendingKeyPath)
+		_ = cleanupPendingRotationKeypair(pendingKeyPath, newDID)
 		_ = removePendingRotationStateOwned(rotationDir, identity.StableID, operationID)
 		return err
 	}
@@ -133,7 +133,7 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		var outcomeErr *awid.DIDRotationError
 		if errors.As(err, &outcomeErr) && outcomeErr.Outcome == awid.DIDRotationDefinitelyNotApplied {
-			if cleanupErr := cleanupPendingRotationKeypair(pendingKeyPath); cleanupErr != nil {
+			if cleanupErr := cleanupPendingRotationKeypair(pendingKeyPath, newDID); cleanupErr != nil {
 				return fmt.Errorf("%w; failed to discard the unused replacement signing key: %v", err, cleanupErr)
 			}
 			if cleanupErr := removePendingRotationStateOwned(rotationDir, identity.StableID, operationID); cleanupErr != nil {

--- a/cli/go/cmd/aw/id_rotate_key.go
+++ b/cli/go/cmd/aw/id_rotate_key.go
@@ -68,6 +68,9 @@ func runIDRotateKey(cmd *cobra.Command, args []string) error {
 		printOutput(out, formatIDRotationRecovery)
 		return nil
 	}
+	if err := validateResolvedIdentity(identity); err != nil {
+		return err
+	}
 	signingKey, err := resolveIdentitySigningKey(identity)
 	if err != nil {
 		return err

--- a/cli/go/cmd/aw/id_rotate_key_crash_unix_test.go
+++ b/cli/go/cmd/aw/id_rotate_key_crash_unix_test.go
@@ -141,6 +141,33 @@ func TestAwIDRotationRecoveryRepairsPublicKeyBeforePendingPublicCleanup(t *testi
 		wantState: true, wantPendingPublic: true, wantActivePrivateNew: true,
 		wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true,
 	})
+	activePath := awconfig.WorktreeSigningKeyPath(dir)
+	activePrivate, err := awid.LoadSigningKey(activePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeTemp := filepath.Join(filepath.Dir(activePath), ".tmp.owned-active-rotation")
+	if err := awid.SaveSigningKey(activeTemp, activePrivate); err != nil {
+		t.Fatal(err)
+	}
+	archivePrivate, _ := archivedRotationKeyPaths(activePath, oldDID)
+	archiveOldPrivate, err := awid.LoadSigningKey(archivePrivate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveTemp := filepath.Join(filepath.Dir(archivePrivate), ".tmp.owned-archive-rotation")
+	if err := awid.SaveSigningKey(archiveTemp, archiveOldPrivate); err != nil {
+		t.Fatal(err)
+	}
+	activeTempBytes := readFileForCrashTest(t, activeTemp)
+	archiveTempBytes := readFileForCrashTest(t, archiveTemp)
+	if got, want := pathSigningKeyDID(activeTemp), crashRegistryProposedDID(fixture); got != want {
+		t.Fatalf("promoted-key temp did=%q, want operation new DID %q", got, want)
+	}
+	if got := pathSigningKeyDID(archiveTemp); got != oldDID {
+		t.Fatalf("archived-key temp did=%q, want operation old DID %q", got, oldDID)
+	}
+
 	killRotationCommandAtCheckpoint(t, ctx, bin, dir, "after-pending-public-removal", "/rotation/pending/", "recover")
 
 	rotationDir := filepath.Join(dir, ".aw", "rotation")
@@ -153,9 +180,14 @@ func TestAwIDRotationRecoveryRepairsPublicKeyBeforePendingPublicCleanup(t *testi
 	}
 	assertCrashPathExists(t, pending.PendingKey, false)
 	assertCrashPathExists(t, awid.PublicKeyPath(pending.PendingKey), false)
-	activePath := awconfig.WorktreeSigningKeyPath(dir)
 	assertSigningKeyDID(t, activePath, pending.NewDID)
 	assertPublicKeyDID(t, awid.PublicKeyPath(activePath), pending.NewDID)
+	if got := readFileForCrashTest(t, activeTemp); !bytes.Equal(got, activeTempBytes) {
+		t.Fatal("recovery changed promoted-key temp before its cleanup phase")
+	}
+	if got := readFileForCrashTest(t, archiveTemp); !bytes.Equal(got, archiveTempBytes) {
+		t.Fatal("recovery changed archived-key temp before its cleanup phase")
+	}
 	if identity := loadIdentityForTest(t, dir); identity.DID != pending.NewDID {
 		t.Fatalf("identity did=%q, want %q", identity.DID, pending.NewDID)
 	}
@@ -166,6 +198,8 @@ func TestAwIDRotationRecoveryRepairsPublicKeyBeforePendingPublicCleanup(t *testi
 		t.Fatalf("second recovery status=%q, want finalized", recovered.Status)
 	}
 	assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, foreign)
+	assertCrashPathExists(t, activeTemp, false)
+	assertCrashPathExists(t, archiveTemp, false)
 }
 
 func TestAwIDRotationRecoveryRemovesOwnedPrivateKeyTempResidue(t *testing.T) {

--- a/cli/go/cmd/aw/id_rotate_key_crash_unix_test.go
+++ b/cli/go/cmd/aw/id_rotate_key_crash_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -115,7 +116,12 @@ func TestAwIDRotationCrashMatrixRecoversConsistently(t *testing.T) {
 	}
 }
 
-func TestAwIDRotationCrashCheckpointIsInertWithoutCompleteCapability(t *testing.T) {
+func TestAwIDRotationRecoveryRepairsPublicKeyBeforePendingPublicCleanup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	root := t.TempDir()
+	bin := filepath.Join(root, "aw")
+	buildAwBinary(t, ctx, bin)
 	oldPublic, oldPrivate, err := awid.GenerateKeypair()
 	if err != nil {
 		t.Fatal(err)
@@ -123,55 +129,215 @@ func TestAwIDRotationCrashCheckpointIsInertWithoutCompleteCapability(t *testing.
 	oldDID := awid.ComputeDIDKey(oldPublic)
 	stableID := awid.ComputeStableID(oldPublic)
 	fixture, registryState := newRotationCrashRegistry(t, stableID, oldDID, rotationRegistrySuccess)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "aw")
-	buildAwBinary(t, ctx, bin)
+	dir := filepath.Join(root, "split-recovery-crash")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPrivate)
+	foreign := seedForeignRotationOperation(t, dir)
 
-	readyReader, readyWriter, err := os.Pipe()
+	killRotationAtCheckpoint(t, ctx, bin, dir, "after-active-private-rename", "")
+	assertRotationCrashState(t, dir, stableID, oldDID, fixture, rotationCrashCase{
+		wantState: true, wantPendingPublic: true, wantActivePrivateNew: true,
+		wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true,
+	})
+	killRotationCommandAtCheckpoint(t, ctx, bin, dir, "after-pending-public-removal", "/rotation/pending/", "recover")
+
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	pending, err := loadPendingRotationState(rotationDir, stableID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	controlReader, controlWriter, err := os.Pipe()
+	if pending == nil {
+		t.Fatal("recovery removed operation state before the public-cleanup checkpoint")
+	}
+	assertCrashPathExists(t, pending.PendingKey, false)
+	assertCrashPathExists(t, awid.PublicKeyPath(pending.PendingKey), false)
+	activePath := awconfig.WorktreeSigningKeyPath(dir)
+	assertSigningKeyDID(t, activePath, pending.NewDID)
+	assertPublicKeyDID(t, awid.PublicKeyPath(activePath), pending.NewDID)
+	if identity := loadIdentityForTest(t, dir); identity.DID != pending.NewDID {
+		t.Fatalf("identity did=%q, want %q", identity.DID, pending.NewDID)
+	}
+	assertForeignRotationOperation(t, foreign)
+
+	recovered := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")
+	if recovered.Status != "finalized" {
+		t.Fatalf("second recovery status=%q, want finalized", recovered.Status)
+	}
+	assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, foreign)
+}
+
+func TestAwIDRotationRecoveryRemovesOwnedPrivateKeyTempResidue(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	root := t.TempDir()
+	bin := filepath.Join(root, "aw")
+	buildAwBinary(t, ctx, bin)
+	oldPublic, oldPrivate, err := awid.GenerateKeypair()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer readyReader.Close()
-	defer controlWriter.Close()
-	cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "--json")
-	cmd.Dir = dir
-	cmd.ExtraFiles = []*os.File{readyWriter, controlReader}
-	// Point and FDs without the exact protocol must remain inert on the same full
-	// rotate path used by the SIGKILL cases.
-	cmd.Env = append(testCommandEnv(dir),
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT=after-key-generation",
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD=3",
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD=4",
-	)
-	var output bytes.Buffer
-	cmd.Stdout = &output
-	cmd.Stderr = &output
-	if err := cmd.Start(); err != nil {
+	oldDID := awid.ComputeDIDKey(oldPublic)
+	stableID := awid.ComputeStableID(oldPublic)
+	fixture, registryState := newRotationCrashRegistry(t, stableID, oldDID, rotationRegistrySuccess)
+	dir := filepath.Join(root, "private-temp-residue")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	_ = readyWriter.Close()
-	_ = controlReader.Close()
-	if err := readyReader.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPrivate)
+	foreign := seedForeignRotationOperation(t, dir)
+
+	killRotationAtCheckpoint(t, ctx, bin, dir, "after-private-key-temp-sync", "/rotation/pending/")
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	pending, err := loadPendingRotationState(rotationDir, stableID)
+	if err != nil {
 		t.Fatal(err)
 	}
-	var marker [1]byte
-	if count, readErr := readyReader.Read(marker[:]); count != 0 || readErr == nil {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-		t.Fatalf("inert checkpoint wrote a marker: count=%d err=%v", count, readErr)
+	if pending == nil {
+		t.Fatal("private-key write crash did not retain owned operation state")
 	}
-	if err := cmd.Wait(); err != nil {
-		t.Fatalf("rotation with inert checkpoint capability failed: %v\n%s", err, output.String())
+	matches, err := filepath.Glob(filepath.Join(rotationDir, "pending", ".tmp.*"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, nil)
+	var ownedTemp string
+	for _, match := range matches {
+		if match != foreign.tempPath {
+			if ownedTemp != "" {
+				t.Fatalf("multiple rotation-owned private-key temps: %s and %s", ownedTemp, match)
+			}
+			ownedTemp = match
+		}
+	}
+	if ownedTemp == "" {
+		t.Fatal("SIGKILL did not leave the representative private-key temp residue")
+	}
+	if got := pathSigningKeyDID(ownedTemp); got != pending.NewDID {
+		t.Fatalf("orphan temp private key did=%q, want operation new DID %q", got, pending.NewDID)
+	}
+	assertForeignRotationOperation(t, foreign)
+
+	recovered := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")
+	if recovered.Status != "rolled_back" {
+		t.Fatalf("temp-residue recovery status=%q, want rolled_back", recovered.Status)
+	}
+	assertNoOwnedRotationFiles(t, rotationDir, foreign)
+	assertForeignRotationOperation(t, foreign)
+	out, err := runRotateKeyCommand(ctx, bin, dir)
+	if err != nil {
+		t.Fatalf("rotation after temp-residue recovery failed: %v\n%s", err, out)
+	}
+	assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, foreign)
+}
+
+func TestAwIDRotationCrashCheckpointIsInertWithoutCompleteCapability(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	root := t.TempDir()
+	bin := filepath.Join(root, "aw")
+	buildAwBinary(t, ctx, bin)
+
+	cases := []struct {
+		name      string
+		unset     string
+		overrides map[string]string
+	}{
+		{name: "missing protocol", unset: "AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL"},
+		{name: "wrong protocol", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL": "wrong-version"}},
+		{name: "wrong checkpoint", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT": "not-a-checkpoint"}},
+		{name: "missing ready fd", unset: "AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD"},
+		{name: "malformed ready fd", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD": "not-a-fd"}},
+		{name: "non-inherited ready fd", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD": "2"}},
+		{name: "missing control fd", unset: "AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD"},
+		{name: "malformed control fd", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD": "not-a-fd"}},
+		{name: "non-inherited control fd", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD": "2"}},
+		{name: "same descriptors", overrides: map[string]string{"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD": "3"}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			oldPublic, oldPrivate, err := awid.GenerateKeypair()
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldDID := awid.ComputeDIDKey(oldPublic)
+			stableID := awid.ComputeStableID(oldPublic)
+			fixture, registryState := newRotationCrashRegistry(t, stableID, oldDID, rotationRegistrySuccess)
+			dir := filepath.Join(root, strings.ReplaceAll(testCase.name, " ", "-"))
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPrivate)
+
+			readyReader, readyWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			controlReader, controlWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer readyReader.Close()
+			defer controlWriter.Close()
+			cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "--json")
+			cmd.Dir = dir
+			cmd.ExtraFiles = []*os.File{readyWriter, controlReader}
+			capability := map[string]string{
+				"AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL":   rotationCrashTestProtocol,
+				"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT":      "after-key-generation",
+				"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD":   "3",
+				"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD": "4",
+			}
+			delete(capability, testCase.unset)
+			for key, value := range testCase.overrides {
+				capability[key] = value
+			}
+			cmd.Env = rotationCrashCapabilityEnv(testCommandEnv(dir), capability)
+			var output bytes.Buffer
+			cmd.Stdout = &output
+			cmd.Stderr = &output
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			_ = readyWriter.Close()
+			_ = controlReader.Close()
+			if err := readyReader.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			var marker [1]byte
+			count, readErr := readyReader.Read(marker[:])
+			if count != 0 || readErr != io.EOF {
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+				t.Fatalf("incomplete checkpoint capability wrote or blocked: count=%d err=%v", count, readErr)
+			}
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("rotation with incomplete checkpoint capability failed: %v\n%s", err, output.String())
+			}
+			assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, nil)
+		})
+	}
+}
+
+func rotationCrashCapabilityEnv(base []string, capability map[string]string) []string {
+	keys := map[string]bool{
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL":      true,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT":         true,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD":      true,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD":    true,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PATH_CONTAINS": true,
+	}
+	env := make([]string, 0, len(base)+len(capability))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if !keys[key] {
+			env = append(env, entry)
+		}
+	}
+	for key, value := range capability {
+		env = append(env, key+"="+value)
+	}
+	return env
 }
 
 func runRotationCrashCase(t *testing.T, ctx context.Context, bin, root string, testCase rotationCrashCase) {
@@ -271,6 +437,11 @@ func killRotationAtRegistryWindow(t *testing.T, ctx context.Context, bin, dir st
 
 func killRotationAtCheckpoint(t *testing.T, ctx context.Context, bin, dir, point, pathContains string) {
 	t.Helper()
+	killRotationCommandAtCheckpoint(t, ctx, bin, dir, point, pathContains)
+}
+
+func killRotationCommandAtCheckpoint(t *testing.T, ctx context.Context, bin, dir, point, pathContains string, action ...string) {
+	t.Helper()
 	readyReader, readyWriter, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
@@ -282,16 +453,18 @@ func killRotationAtCheckpoint(t *testing.T, ctx context.Context, bin, dir, point
 	defer readyReader.Close()
 	defer controlWriter.Close()
 
-	cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "--json")
+	args := append([]string{"id", "rotate-key"}, action...)
+	args = append(args, "--json")
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = dir
 	cmd.ExtraFiles = []*os.File{readyWriter, controlReader}
-	cmd.Env = append(testCommandEnv(dir),
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL="+rotationCrashTestProtocol,
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT="+point,
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD=3",
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD=4",
-		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PATH_CONTAINS="+pathContains,
-	)
+	cmd.Env = rotationCrashCapabilityEnv(testCommandEnv(dir), map[string]string{
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL":      rotationCrashTestProtocol,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT":         point,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD":      "3",
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD":    "4",
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PATH_CONTAINS": pathContains,
+	})
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -478,6 +651,8 @@ type foreignRotationOperation struct {
 	private     []byte
 	publicPath  string
 	public      []byte
+	tempPath    string
+	temp        []byte
 }
 
 func seedForeignRotationOperation(t *testing.T, dir string) *foreignRotationOperation {
@@ -502,11 +677,16 @@ func seedForeignRotationOperation(t *testing.T, dir string) *foreignRotationOper
 		t.Fatal(err)
 	}
 	statePath := pendingRotationStatePath(rotationDir, stableID)
+	tempPath := filepath.Join(rotationDir, "pending", ".tmp.foreign-"+operationID)
+	if err := awid.SaveSigningKey(tempPath, priv); err != nil {
+		t.Fatal(err)
+	}
 	return &foreignRotationOperation{
 		rotationDir: rotationDir, stableID: stableID,
 		state:       readFileForCrashTest(t, statePath),
 		privatePath: privatePath, private: readFileForCrashTest(t, privatePath),
 		publicPath: awid.PublicKeyPath(privatePath), public: readFileForCrashTest(t, awid.PublicKeyPath(privatePath)),
+		tempPath: tempPath, temp: readFileForCrashTest(t, tempPath),
 	}
 }
 
@@ -518,6 +698,7 @@ func assertForeignRotationOperation(t *testing.T, foreign *foreignRotationOperat
 	statePath := pendingRotationStatePath(foreign.rotationDir, foreign.stableID)
 	for path, want := range map[string][]byte{
 		statePath: foreign.state, foreign.privatePath: foreign.private, foreign.publicPath: foreign.public,
+		foreign.tempPath: foreign.temp,
 	} {
 		if got := readFileForCrashTest(t, path); !bytes.Equal(got, want) {
 			t.Fatalf("foreign operation file changed at %s", path)
@@ -531,9 +712,18 @@ func assertNoOwnedRotationFiles(t *testing.T, rotationDir string, foreign *forei
 	if foreign != nil {
 		allowed[foreign.privatePath] = true
 		allowed[foreign.publicPath] = true
+		allowed[foreign.tempPath] = true
 	}
-	for _, pattern := range []string{"*.signing.key", "*.signing.pub"} {
-		matches, err := filepath.Glob(filepath.Join(rotationDir, "pending", pattern))
+	pendingDir := filepath.Join(rotationDir, "pending")
+	patterns := []string{
+		filepath.Join(pendingDir, "*.signing.key"),
+		filepath.Join(pendingDir, "*.signing.pub"),
+		filepath.Join(pendingDir, ".tmp.*"),
+		filepath.Join(filepath.Dir(rotationDir), ".tmp.*"),
+		filepath.Join(filepath.Dir(rotationDir), "rotated", ".tmp.*"),
+	}
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cli/go/cmd/aw/id_rotate_key_crash_unix_test.go
+++ b/cli/go/cmd/aw/id_rotate_key_crash_unix_test.go
@@ -1,0 +1,555 @@
+//go:build !windows
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/awebai/aw/awconfig"
+	"github.com/awebai/aw/awid"
+)
+
+const rotationCrashTestProtocol = "aweb-internal-rotation-crash-test-v1"
+
+type rotationCrashRegistryMode string
+
+const (
+	rotationRegistrySuccess      rotationCrashRegistryMode = "success"
+	rotationRegistryReject       rotationCrashRegistryMode = "reject"
+	rotationRegistryBlockOld     rotationCrashRegistryMode = "block-old"
+	rotationRegistryBlockApplied rotationCrashRegistryMode = "block-applied"
+)
+
+type rotationCrashCase struct {
+	name                 string
+	point                string
+	pathContains         string
+	registryMode         rotationCrashRegistryMode
+	wantRecovery         string
+	wantState            bool
+	wantPendingPrivate   bool
+	wantPendingPublic    bool
+	wantActivePrivateNew bool
+	wantActivePublicNew  bool
+	wantIdentityNew      bool
+	wantArchivePrivate   bool
+	wantArchivePublic    bool
+	wantRegistryNew      bool
+	mustPreserveNew      bool
+}
+
+type rotationCrashRegistryState struct {
+	mu      sync.Mutex
+	mode    rotationCrashRegistryMode
+	ready   chan struct{}
+	release chan struct{}
+	applied int
+}
+
+func (s *rotationCrashRegistryState) currentMode() rotationCrashRegistryMode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mode
+}
+
+func (s *rotationCrashRegistryState) setMode(mode rotationCrashRegistryMode) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mode = mode
+}
+
+func (s *rotationCrashRegistryState) recordApply() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applied++
+}
+
+func (s *rotationCrashRegistryState) appliedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.applied
+}
+
+func TestAwIDRotationCrashMatrixRecoversConsistently(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	root := t.TempDir()
+	bin := filepath.Join(root, "aw")
+	buildAwBinary(t, ctx, bin)
+
+	cases := []rotationCrashCase{
+		{name: "A no committed operation state", point: "after-key-generation", registryMode: rotationRegistrySuccess, wantRecovery: "no_pending"},
+		{name: "B ownership state only", point: "after-pending-state-commit", registryMode: rotationRegistrySuccess, wantRecovery: "rolled_back", wantState: true},
+		{name: "C ownership state and private key", point: "after-keypair-private-commit", pathContains: "/rotation/pending/", registryMode: rotationRegistrySuccess, wantRecovery: "rolled_back", wantState: true, wantPendingPrivate: true},
+		{name: "D complete pending key pair before request", point: "after-keypair-public-commit", pathContains: "/rotation/pending/", registryMode: rotationRegistrySuccess, wantRecovery: "rolled_back", wantState: true, wantPendingPrivate: true, wantPendingPublic: true},
+		{name: "E request in flight registry old", registryMode: rotationRegistryBlockOld, wantRecovery: "rolled_back", wantState: true, wantPendingPrivate: true, wantPendingPublic: true, mustPreserveNew: true},
+		{name: "F request applied response withheld", registryMode: rotationRegistryBlockApplied, wantRecovery: "finalized", wantState: true, wantPendingPrivate: true, wantPendingPublic: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "G1 archived private only", point: "after-keypair-private-commit", pathContains: "/rotated/", registryMode: rotationRegistrySuccess, wantRecovery: "finalized", wantState: true, wantPendingPrivate: true, wantPendingPublic: true, wantArchivePrivate: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "G2 complete archived pair", point: "after-keypair-public-commit", pathContains: "/rotated/", registryMode: rotationRegistrySuccess, wantRecovery: "finalized", wantState: true, wantPendingPrivate: true, wantPendingPublic: true, wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "H split active key pair", point: "after-active-private-rename", registryMode: rotationRegistrySuccess, wantRecovery: "finalized", wantState: true, wantPendingPublic: true, wantActivePrivateNew: true, wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "I active pair with old identity", point: "after-active-public-rename", registryMode: rotationRegistrySuccess, wantRecovery: "finalized", wantState: true, wantActivePrivateNew: true, wantActivePublicNew: true, wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "J active pair and identity with pending state", point: "after-identity-state-commit", registryMode: rotationRegistrySuccess, wantRecovery: "finalized", wantState: true, wantActivePrivateNew: true, wantActivePublicNew: true, wantIdentityNew: true, wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "K applied operation complete", point: "after-pending-state-removal", registryMode: rotationRegistrySuccess, wantRecovery: "no_pending", wantActivePrivateNew: true, wantActivePublicNew: true, wantIdentityNew: true, wantArchivePrivate: true, wantArchivePublic: true, wantRegistryNew: true, mustPreserveNew: true},
+		{name: "L rollback private removed", point: "after-pending-private-removal", pathContains: "/rotation/pending/", registryMode: rotationRegistryReject, wantRecovery: "rolled_back", wantState: true, wantPendingPublic: true},
+		{name: "M rollback key pair removed", point: "after-pending-public-removal", pathContains: "/rotation/pending/", registryMode: rotationRegistryReject, wantRecovery: "rolled_back", wantState: true},
+		{name: "N rollback complete", point: "after-pending-state-removal", registryMode: rotationRegistryReject, wantRecovery: "no_pending"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			runRotationCrashCase(t, ctx, bin, root, testCase)
+		})
+	}
+}
+
+func TestAwIDRotationCrashCheckpointIsInertWithoutCompleteCapability(t *testing.T) {
+	oldPublic, oldPrivate, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPublic)
+	stableID := awid.ComputeStableID(oldPublic)
+	fixture, registryState := newRotationCrashRegistry(t, stableID, oldDID, rotationRegistrySuccess)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "aw")
+	buildAwBinary(t, ctx, bin)
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPrivate)
+
+	readyReader, readyWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlReader, controlWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readyReader.Close()
+	defer controlWriter.Close()
+	cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "--json")
+	cmd.Dir = dir
+	cmd.ExtraFiles = []*os.File{readyWriter, controlReader}
+	// Point and FDs without the exact protocol must remain inert on the same full
+	// rotate path used by the SIGKILL cases.
+	cmd.Env = append(testCommandEnv(dir),
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT=after-key-generation",
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD=3",
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD=4",
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	_ = readyWriter.Close()
+	_ = controlReader.Close()
+	if err := readyReader.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var marker [1]byte
+	if count, readErr := readyReader.Read(marker[:]); count != 0 || readErr == nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("inert checkpoint wrote a marker: count=%d err=%v", count, readErr)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("rotation with inert checkpoint capability failed: %v\n%s", err, output.String())
+	}
+	assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, nil)
+}
+
+func runRotationCrashCase(t *testing.T, ctx context.Context, bin, root string, testCase rotationCrashCase) {
+	t.Helper()
+	oldPublic, oldPrivate, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPublic)
+	stableID := awid.ComputeStableID(oldPublic)
+	fixture, registryState := newRotationCrashRegistry(t, stableID, oldDID, testCase.registryMode)
+	dir, err := os.MkdirTemp(root, "rotation-crash-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, fixture.server.URL, oldPrivate)
+	foreign := seedForeignRotationOperation(t, dir)
+
+	if testCase.registryMode == rotationRegistryBlockOld || testCase.registryMode == rotationRegistryBlockApplied {
+		killRotationAtRegistryWindow(t, ctx, bin, dir, registryState)
+	} else {
+		killRotationAtCheckpoint(t, ctx, bin, dir, testCase.point, testCase.pathContains)
+	}
+
+	assertRotationCrashState(t, dir, stableID, oldDID, fixture, testCase)
+	assertForeignRotationOperation(t, foreign)
+
+	recovered := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")
+	if recovered.Status != testCase.wantRecovery {
+		t.Fatalf("post-crash recovery status=%q, want %q", recovered.Status, testCase.wantRecovery)
+	}
+	assertForeignRotationOperation(t, foreign)
+
+	registryState.setMode(rotationRegistrySuccess)
+	if registryState.appliedCount() == 0 {
+		out, err := runRotateKeyCommand(ctx, bin, dir)
+		if err != nil {
+			t.Fatalf("rotation after crash recovery failed: %v\n%s", err, out)
+		}
+	}
+	assertCompletedRotation(t, dir, stableID, oldDID, fixture, registryState, foreign)
+}
+
+func newRotationCrashRegistry(t *testing.T, stableID, oldDID string, mode rotationCrashRegistryMode) (*cliRotationRegistryFixture, *rotationCrashRegistryState) {
+	t.Helper()
+	state := &rotationCrashRegistryState{
+		mode: mode, ready: make(chan struct{}, 1), release: make(chan struct{}),
+	}
+	fixture := newCLIRotationRegistryFixture(t, stableID, oldDID, func(f *cliRotationRegistryFixture, w http.ResponseWriter, _ map[string]any) {
+		switch state.currentMode() {
+		case rotationRegistryReject:
+			http.Error(w, "rotation rejected", http.StatusConflict)
+		case rotationRegistryBlockOld:
+			state.ready <- struct{}{}
+			<-state.release
+			http.Error(w, "rotation interrupted", http.StatusConflict)
+		case rotationRegistryBlockApplied:
+			f.currentDID = f.proposedDID
+			state.recordApply()
+			state.ready <- struct{}{}
+			<-state.release
+			f.dropResponse(w)
+		default:
+			f.currentDID = f.proposedDID
+			state.recordApply()
+			_ = json.NewEncoder(w).Encode(awid.DIDMapping{
+				DIDAW: stableID, CurrentDIDKey: f.proposedDID,
+				CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+			})
+		}
+	})
+	return fixture, state
+}
+
+func killRotationAtRegistryWindow(t *testing.T, ctx context.Context, bin, dir string, state *rotationCrashRegistryState) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "--json")
+	cmd.Dir = dir
+	cmd.Env = testCommandEnv(dir)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-state.ready:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("rotation did not reach registry crash window\n%s", output.String())
+	}
+	signalRotationSIGKILL(t, cmd)
+	close(state.release)
+	waitForRotationSIGKILL(t, cmd)
+}
+
+func killRotationAtCheckpoint(t *testing.T, ctx context.Context, bin, dir, point, pathContains string) {
+	t.Helper()
+	readyReader, readyWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlReader, controlWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readyReader.Close()
+	defer controlWriter.Close()
+
+	cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", "--json")
+	cmd.Dir = dir
+	cmd.ExtraFiles = []*os.File{readyWriter, controlReader}
+	cmd.Env = append(testCommandEnv(dir),
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL="+rotationCrashTestProtocol,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT="+point,
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD=3",
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD=4",
+		"AWEB_INTERNAL_ROTATION_CRASH_TEST_PATH_CONTAINS="+pathContains,
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	_ = readyWriter.Close()
+	_ = controlReader.Close()
+
+	if err := readyReader.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	gotPoint, err := bufio.NewReader(readyReader).ReadString('\n')
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("rotation exited before crash checkpoint %q: %v\n%s", point, err, output.String())
+	}
+	if strings.TrimSpace(gotPoint) != point {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("crash checkpoint=%q, want %q", strings.TrimSpace(gotPoint), point)
+	}
+	signalRotationSIGKILL(t, cmd)
+	waitForRotationSIGKILL(t, cmd)
+}
+
+func signalRotationSIGKILL(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForRotationSIGKILL(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("SIGKILLed rotation exited successfully")
+	}
+	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGKILL {
+		t.Fatalf("rotation exit status=%v, want SIGKILL", cmd.ProcessState.Sys())
+	}
+}
+
+func assertRotationCrashState(t *testing.T, dir, stableID, oldDID string, fixture *cliRotationRegistryFixture, want rotationCrashCase) {
+	t.Helper()
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	pending, err := loadPendingRotationState(rotationDir, stableID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if (pending != nil) != want.wantState {
+		t.Fatalf("pending state=%+v, want present=%v", pending, want.wantState)
+	}
+	newDID := crashRegistryProposedDID(fixture)
+	if pending != nil {
+		newDID = pending.NewDID
+		assertCrashPathExists(t, pending.PendingKey, want.wantPendingPrivate)
+		assertCrashPathExists(t, awid.PublicKeyPath(pending.PendingKey), want.wantPendingPublic)
+	}
+	activePath := awconfig.WorktreeSigningKeyPath(dir)
+	assertSigningKeyDID(t, activePath, chooseDID(want.wantActivePrivateNew, oldDID, newDID))
+	assertPublicKeyDID(t, awid.PublicKeyPath(activePath), chooseDID(want.wantActivePublicNew, oldDID, newDID))
+	identity := loadIdentityForTest(t, dir)
+	if identity.DID != chooseDID(want.wantIdentityNew, oldDID, newDID) {
+		t.Fatalf("identity did=%q", identity.DID)
+	}
+	archivePrivate, archivePublic := archivedRotationKeyPaths(activePath, oldDID)
+	assertCrashPathExists(t, archivePrivate, want.wantArchivePrivate)
+	assertCrashPathExists(t, archivePublic, want.wantArchivePublic)
+	registryDID := crashRegistryCurrentDID(fixture)
+	if registryDID != chooseDID(want.wantRegistryNew, oldDID, newDID) {
+		t.Fatalf("registry did=%q", registryDID)
+	}
+	if want.mustPreserveNew && newDID != "" {
+		pendingHasNew := pending != nil && pathSigningKeyDID(pending.PendingKey) == newDID
+		activeHasNew := pathSigningKeyDID(activePath) == newDID
+		if !pendingHasNew && !activeHasNew {
+			t.Fatalf("new private key %s was not preserved", newDID)
+		}
+	}
+}
+
+func assertCompletedRotation(t *testing.T, dir, stableID, oldDID string, fixture *cliRotationRegistryFixture, registryState *rotationCrashRegistryState, foreign *foreignRotationOperation) {
+	t.Helper()
+	applied := registryState.appliedCount()
+	if applied != 1 {
+		t.Fatalf("authoritative registry applies=%d, want 1", applied)
+	}
+	registryDID := crashRegistryCurrentDID(fixture)
+	identity := loadIdentityForTest(t, dir)
+	if identity.DID != registryDID {
+		t.Fatalf("identity did=%q, registry did=%q", identity.DID, registryDID)
+	}
+	activePath := awconfig.WorktreeSigningKeyPath(dir)
+	assertSigningKeyDID(t, activePath, registryDID)
+	assertPublicKeyDID(t, awid.PublicKeyPath(activePath), registryDID)
+	archivePrivate, archivePublic := archivedRotationKeyPaths(activePath, oldDID)
+	assertCrashPathExists(t, archivePrivate, true)
+	assertCrashPathExists(t, archivePublic, true)
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	if pending, err := loadPendingRotationState(rotationDir, stableID); err != nil {
+		t.Fatal(err)
+	} else if pending != nil {
+		t.Fatalf("pending rotation state remains: %+v", pending)
+	}
+	assertNoOwnedRotationFiles(t, rotationDir, foreign)
+	if foreign != nil {
+		assertForeignRotationOperation(t, foreign)
+	}
+}
+
+func crashRegistryCurrentDID(fixture *cliRotationRegistryFixture) string {
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	return fixture.currentDID
+}
+
+func crashRegistryProposedDID(fixture *cliRotationRegistryFixture) string {
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	return fixture.proposedDID
+}
+
+func chooseDID(useNew bool, oldDID, newDID string) string {
+	if useNew {
+		return newDID
+	}
+	return oldDID
+}
+
+func assertSigningKeyDID(t *testing.T, path, want string) {
+	t.Helper()
+	key, err := awid.LoadSigningKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := awid.ComputeDIDKey(key.Public().(ed25519.PublicKey)); got != want {
+		t.Fatalf("private key %s did=%q, want %q", path, got, want)
+	}
+}
+
+func assertPublicKeyDID(t *testing.T, path, want string) {
+	t.Helper()
+	key, err := awid.LoadPublicKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := awid.ComputeDIDKey(key); got != want {
+		t.Fatalf("public key %s did=%q, want %q", path, got, want)
+	}
+}
+
+func pathSigningKeyDID(path string) string {
+	key, err := awid.LoadSigningKey(path)
+	if err != nil {
+		return ""
+	}
+	return awid.ComputeDIDKey(key.Public().(ed25519.PublicKey))
+}
+
+func assertCrashPathExists(t *testing.T, path string, want bool) {
+	t.Helper()
+	_, err := os.Stat(path)
+	if want && err != nil {
+		t.Fatalf("expected path %s: %v", path, err)
+	}
+	if !want && !os.IsNotExist(err) {
+		t.Fatalf("unexpected path %s: %v", path, err)
+	}
+}
+
+func archivedRotationKeyPaths(activePath, oldDID string) (string, string) {
+	base := filepath.Join(filepath.Dir(activePath), "rotated", pendingFileBase(oldDID))
+	return base + ".key", base + ".pub"
+}
+
+type foreignRotationOperation struct {
+	rotationDir string
+	stableID    string
+	state       []byte
+	privatePath string
+	private     []byte
+	publicPath  string
+	public      []byte
+}
+
+func seedForeignRotationOperation(t *testing.T, dir string) *foreignRotationOperation {
+	t.Helper()
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	operationID := "ffffffff-ffff-4fff-8fff-ffffffffffff"
+	stableID := "did:aw:foreign-operation"
+	pub, priv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	privatePath, err := savePendingRotationKeypair(rotationDir, operationID, pub, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := &pendingRotationState{
+		OperationID: operationID, StableID: stableID,
+		OldDID: "did:key:foreign-old", NewDID: awid.ComputeDIDKey(pub),
+		PendingKey: privatePath,
+	}
+	if err := savePendingRotationState(rotationDir, state); err != nil {
+		t.Fatal(err)
+	}
+	statePath := pendingRotationStatePath(rotationDir, stableID)
+	return &foreignRotationOperation{
+		rotationDir: rotationDir, stableID: stableID,
+		state:       readFileForCrashTest(t, statePath),
+		privatePath: privatePath, private: readFileForCrashTest(t, privatePath),
+		publicPath: awid.PublicKeyPath(privatePath), public: readFileForCrashTest(t, awid.PublicKeyPath(privatePath)),
+	}
+}
+
+func assertForeignRotationOperation(t *testing.T, foreign *foreignRotationOperation) {
+	t.Helper()
+	if foreign == nil {
+		return
+	}
+	statePath := pendingRotationStatePath(foreign.rotationDir, foreign.stableID)
+	for path, want := range map[string][]byte{
+		statePath: foreign.state, foreign.privatePath: foreign.private, foreign.publicPath: foreign.public,
+	} {
+		if got := readFileForCrashTest(t, path); !bytes.Equal(got, want) {
+			t.Fatalf("foreign operation file changed at %s", path)
+		}
+	}
+}
+
+func assertNoOwnedRotationFiles(t *testing.T, rotationDir string, foreign *foreignRotationOperation) {
+	t.Helper()
+	allowed := map[string]bool{}
+	if foreign != nil {
+		allowed[foreign.privatePath] = true
+		allowed[foreign.publicPath] = true
+	}
+	for _, pattern := range []string{"*.signing.key", "*.signing.pub"} {
+		matches, err := filepath.Glob(filepath.Join(rotationDir, "pending", pattern))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, match := range matches {
+			if !allowed[match] {
+				t.Fatalf("completed operation key file remains: %s", match)
+			}
+		}
+	}
+}
+
+func readFileForCrashTest(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -245,7 +245,7 @@ func recoverPendingRotation(ctx context.Context, identity *awconfig.ResolvedIden
 			out.Detail = "registry uses the old key, but " + detail + "; replacement key and state preserved"
 			return out, nil
 		}
-		if err := cleanupPendingRotationKeypair(state.PendingKey); err != nil {
+		if err := cleanupPendingRotationKeypair(state.PendingKey, state.NewDID); err != nil {
 			return idRotationRecoveryOutput{}, fmt.Errorf("discard unapplied replacement key for operation %s: %w", state.OperationID, err)
 		}
 		if err := removePendingRotationStateOwned(rotationDir, state.StableID, state.OperationID); err != nil {
@@ -317,8 +317,15 @@ func finalizePendingRotation(identity *awconfig.ResolvedIdentity, rotationDir st
 	}
 	// Crash-test observation only; active key files and identity now agree.
 	crashtest.Checkpoint("after-identity-state-commit", identity.IdentityPath)
-	if err := cleanupPendingRotationKeypair(state.PendingKey); err != nil {
+	if err := cleanupPendingRotationKeypair(state.PendingKey, state.NewDID); err != nil {
 		return fmt.Errorf("clean pending rotation key material: %w", err)
+	}
+	activeDir := filepath.Dir(identity.SigningKeyPath)
+	if err := cleanupMatchingRotationPrivateTemps(activeDir, state.NewDID); err != nil {
+		return fmt.Errorf("clean promoted rotation key temp material: %w", err)
+	}
+	if err := cleanupMatchingRotationPrivateTemps(filepath.Join(activeDir, "rotated"), state.OldDID); err != nil {
+		return fmt.Errorf("clean archived rotation key temp material: %w", err)
 	}
 	if err := removePendingRotationStateOwned(rotationDir, state.StableID, state.OperationID); err != nil {
 		return fmt.Errorf("remove finalized rotation state: %w", err)

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func runIDRotateKeyRecover(cmd *cobra.Command, args []string) error {
-	identity, rotationDir, lockPath, err := prepareRotationIdentity(true)
+	identity, rotationDir, lockPath, err := prepareRotationIdentity(false)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func runIDRotateKeyStatus(cmd *cobra.Command, args []string) error {
 }
 
 func prepareRotationIdentity(requireSigningKey bool) (*awconfig.ResolvedIdentity, string, string, error) {
-	identity, err := resolveIdentity()
+	identity, err := resolveRotationIdentity()
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -145,8 +145,31 @@ func prepareRotationIdentity(requireSigningKey bool) (*awconfig.ResolvedIdentity
 	return identity, rotationDir, lockPath, nil
 }
 
+func resolveRotationIdentity() (*awconfig.ResolvedIdentity, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	identityHome, err := identityHomeForDir(workingDir)
+	if err != nil {
+		return nil, err
+	}
+	identity, err := awconfig.ResolveIdentityFromHome(workingDir, identityHome.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return resolveEphemeralIdentityWithoutState(workingDir)
+	}
+	if err != nil {
+		return nil, err
+	}
+	identity.ExternalIdentityHome = identityHome.External()
+	if strings.TrimSpace(identity.DID) == "" {
+		return nil, usageError("current identity is invalid: .aw/identity.yaml is missing did")
+	}
+	return identity, nil
+}
+
 func reloadRotationIdentity(lockIdentity *awconfig.ResolvedIdentity, rotationDir string) (*awconfig.ResolvedIdentity, error) {
-	identity, err := resolveIdentity()
+	identity, err := resolveRotationIdentity()
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +179,6 @@ func reloadRotationIdentity(lockIdentity *awconfig.ResolvedIdentity, rotationDir
 	}
 	if strings.TrimSpace(identity.StableID) != strings.TrimSpace(lockIdentity.StableID) || filepath.Clean(currentRotationDir) != filepath.Clean(rotationDir) {
 		return nil, fmt.Errorf("active identity changed while waiting for the rotation lock; retry the command")
-	}
-	signingKey, err := resolveIdentitySigningKey(identity)
-	if err != nil {
-		return nil, err
-	}
-	if err := requirePersistentSelfCustodialIdentity(identity, signingKey); err != nil {
-		return nil, err
 	}
 	return identity, nil
 }

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/awebai/aw/awconfig"
 	"github.com/awebai/aw/awid"
+	"github.com/awebai/aw/internal/crashtest"
 	"github.com/spf13/cobra"
 )
 
@@ -303,6 +304,8 @@ func finalizePendingRotation(identity *awconfig.ResolvedIdentity, rotationDir st
 	if err := awconfig.SaveWorktreeIdentityTo(identity.IdentityPath, local); err != nil {
 		return fmt.Errorf("update local identity state: %w", err)
 	}
+	// Crash-test observation only; active key files and identity now agree.
+	crashtest.Checkpoint("after-identity-state-commit", identity.IdentityPath)
 	if err := cleanupPendingRotationKeypair(state.PendingKey); err != nil {
 		return fmt.Errorf("clean pending rotation key material: %w", err)
 	}

--- a/cli/go/cmd/aw/id_rotate_key_recover.go
+++ b/cli/go/cmd/aw/id_rotate_key_recover.go
@@ -67,6 +67,11 @@ func runIDRotateKeyRecover(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if out.Status == "no_pending" {
+		if err := validateResolvedIdentity(identity); err != nil {
+			return err
+		}
+	}
 	printOutput(out, formatIDRotationRecovery)
 	return nil
 }
@@ -99,6 +104,9 @@ func runIDRotateKeyStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if state == nil {
+		if err := validateResolvedIdentity(identity); err != nil {
+			return err
+		}
 		printOutput(idRotationRecoveryOutput{
 			Status: "no_pending", StableID: identity.StableID,
 			StatePath: pendingRotationStatePath(rotationDir, identity.StableID),
@@ -127,6 +135,9 @@ func prepareRotationIdentity(requireSigningKey bool) (*awconfig.ResolvedIdentity
 		return nil, "", "", fmt.Errorf("current identity is missing a did:aw stable identifier")
 	}
 	if requireSigningKey {
+		if err := validateResolvedIdentity(identity); err != nil {
+			return nil, "", "", err
+		}
 		signingKey, err := resolveIdentitySigningKey(identity)
 		if err != nil {
 			return nil, "", "", err

--- a/cli/go/cmd/aw/id_rotation_recovery.go
+++ b/cli/go/cmd/aw/id_rotation_recovery.go
@@ -139,7 +139,7 @@ func preflightRotationFile(path string) error {
 	return pathpreflight.PreflightFile(path, "rotation recovery file", pathpreflight.AllowTempAmbientSymlinkPrefix())
 }
 
-func cleanupPendingRotationKeypair(keyPath string) error {
+func cleanupPendingRotationKeypair(keyPath, expectedDID string) error {
 	for index, path := range []string{keyPath, awid.PublicKeyPath(keyPath)} {
 		if err := preflightRotationFile(path); err != nil {
 			return err
@@ -153,6 +153,39 @@ func cleanupPendingRotationKeypair(keyPath string) error {
 			point = "after-pending-public-removal"
 		}
 		crashtest.Checkpoint(point, path)
+	}
+	return cleanupMatchingRotationPrivateTemps(filepath.Dir(keyPath), expectedDID)
+}
+
+func cleanupMatchingRotationPrivateTemps(dir, expectedDID string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() || !strings.HasPrefix(entry.Name(), ".tmp.") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if err := preflightRotationFile(path); err != nil {
+			return err
+		}
+		key, err := awid.LoadSigningKey(path)
+		if err != nil {
+			continue
+		}
+		// Atomic temp names do not encode their destination. Bind residue to this
+		// operation by key identity; preserve every unknown or foreign temp.
+		did := awid.ComputeDIDKey(key.Public().(ed25519.PublicKey))
+		if strings.TrimSpace(did) != strings.TrimSpace(expectedDID) {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
 	}
 	return nil
 }

--- a/cli/go/cmd/aw/id_rotation_recovery.go
+++ b/cli/go/cmd/aw/id_rotation_recovery.go
@@ -278,5 +278,11 @@ func loadRotationSigningKey(activeKeyPath string, pending *pendingRotationState)
 	if strings.TrimSpace(awid.ComputeDIDKey(activePriv.Public().(ed25519.PublicKey))) != strings.TrimSpace(pending.NewDID) {
 		return nil, false, fmt.Errorf("load pending rotation key: %w", err)
 	}
+	// A crash may have moved the pending private key onto the active path but
+	// not its public sibling. Repair the pair before cleanup removes the only
+	// remaining copy of the replacement public key.
+	if err := ensurePublicKeyMatchesPrivate(activeKeyPath); err != nil {
+		return nil, false, fmt.Errorf("repair promoted signing key pair: %w", err)
+	}
 	return activePriv, true, nil
 }

--- a/cli/go/cmd/aw/id_rotation_recovery.go
+++ b/cli/go/cmd/aw/id_rotation_recovery.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/awebai/aw/awconfig"
 	"github.com/awebai/aw/awid"
+	"github.com/awebai/aw/internal/crashtest"
 	"github.com/awebai/aw/internal/pathpreflight"
 	"gopkg.in/yaml.v3"
 )
@@ -115,6 +116,8 @@ func removePendingRotationStateOwned(rotationDir, stableID, operationID string) 
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	// Crash-test observation only; owned state removal is the transaction end.
+	crashtest.Checkpoint("after-pending-state-removal", path)
 	return nil
 }
 
@@ -137,13 +140,19 @@ func preflightRotationFile(path string) error {
 }
 
 func cleanupPendingRotationKeypair(keyPath string) error {
-	for _, path := range []string{keyPath, awid.PublicKeyPath(keyPath)} {
+	for index, path := range []string{keyPath, awid.PublicKeyPath(keyPath)} {
 		if err := preflightRotationFile(path); err != nil {
 			return err
 		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
+		// Crash-test observation only; each removal exposes a distinct recovery state.
+		point := "after-pending-private-removal"
+		if index == 1 {
+			point = "after-pending-public-removal"
+		}
+		crashtest.Checkpoint(point, path)
 	}
 	return nil
 }
@@ -234,12 +243,15 @@ func promotePendingRotationKeypair(activeKeyPath string, pendingKeyPath string, 
 	if err := os.Rename(pendingKeyPath, activeKeyPath); err != nil {
 		return "", err
 	}
+	// Crash-test observation only; the active key pair is intentionally split here.
+	crashtest.Checkpoint("after-active-private-rename", activeKeyPath)
 	if err := os.Rename(awid.PublicKeyPath(pendingKeyPath), awid.PublicKeyPath(activeKeyPath)); err != nil {
 		if recoverErr := ensurePublicKeyMatchesPrivate(activeKeyPath); recoverErr == nil {
 			return activeKeyPath, nil
 		}
 		return "", err
 	}
+	crashtest.Checkpoint("after-active-public-rename", awid.PublicKeyPath(activeKeyPath))
 	return activeKeyPath, nil
 }
 

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -117,8 +117,12 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 		wantPending         bool
 		wantActiveNew       bool
 		localPromoted       bool
+		splitPromoted       bool
+		plainRecovery       bool
 	}{
 		{name: "applied", registryState: "new", wantStatus: "finalized", wantActiveNew: true},
+		{name: "applied after split active-key promotion", registryState: "new", wantStatus: "finalized", wantActiveNew: true, splitPromoted: true},
+		{name: "plain rotate recovers split active-key promotion", registryState: "new", wantStatus: "finalized", wantActiveNew: true, splitPromoted: true, plainRecovery: true},
 		{name: "not applied", registryState: "old", wantStatus: "rolled_back"},
 		{name: "old key from another identity", registryState: "old", responseDIDAW: &wrongDIDAW, overrideResponseDID: true, wantStatus: "unknown_preserved", wantPending: true},
 		{name: "new key from another identity", registryState: "new", responseDIDAW: &wrongDIDAW, overrideResponseDID: true, wantStatus: "unknown_preserved", wantPending: true},
@@ -181,10 +185,22 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+			if tc.splitPromoted {
+				if err := os.Rename(pendingKey, awconfig.WorktreeSigningKeyPath(dir)); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-			out := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")
+			action := []string{"recover"}
+			if tc.plainRecovery {
+				action = nil
+			}
+			out := runRotationRecoveryCommand(t, ctx, bin, dir, action...)
 			if out.Status != tc.wantStatus {
 				t.Fatalf("recover status=%q, want %q", out.Status, tc.wantStatus)
+			}
+			if out.RerunRequired != tc.plainRecovery {
+				t.Fatalf("recover rerun_required=%v, want %v", out.RerunRequired, tc.plainRecovery)
 			}
 			pending, err := loadPendingRotationState(rotationDir, stableID)
 			if err != nil {
@@ -213,6 +229,13 @@ func TestAwIDRotateKeyRecoverReconcilesAuthoritativeState(t *testing.T) {
 			}
 			if gotActive != wantActive {
 				t.Fatalf("active did=%q, want %q", gotActive, wantActive)
+			}
+			activePublic, err := awid.LoadPublicKey(awid.PublicKeyPath(awconfig.WorktreeSigningKeyPath(dir)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !active.Public().(ed25519.PublicKey).Equal(activePublic) {
+				t.Fatal("active signing private/public key files do not match after recovery")
 			}
 			if !tc.wantPending {
 				repeated := runRotationRecoveryCommand(t, ctx, bin, dir, "recover")

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -293,6 +293,43 @@ func TestAwIDRotateKeyWithPendingStateRecoversAndRequiresRerun(t *testing.T) {
 	}
 }
 
+func TestAwIDRotationRecoveryWithoutPendingStateStillRejectsIdentityKeyMismatch(t *testing.T) {
+	oldPub, oldPriv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	newPub, newPriv, err := awid.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDID := awid.ComputeDIDKey(oldPub)
+	stableID := awid.ComputeStableID(oldPub)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "aw")
+	buildAwBinary(t, ctx, bin)
+	writeStandaloneSelfCustodyIdentity(t, dir, "acme.com/alice", oldDID, stableID, "https://registry.invalid", oldPriv)
+	if err := awid.SaveKeypairAt(
+		awconfig.WorktreeSigningKeyPath(dir),
+		awid.PublicKeyPath(awconfig.WorktreeSigningKeyPath(dir)),
+		newPub,
+		newPriv,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, action := range []string{"recover", "status"} {
+		cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", action, "--json")
+		cmd.Env = testCommandEnv(dir)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err == nil || !strings.Contains(string(out), "does not match .aw/signing.key") {
+			t.Fatalf("%s mismatch error=%v\n%s", action, err, out)
+		}
+	}
+}
+
 func TestAwIDRotateKeyStatusIsReadOnlyAndDistinguishesActiveOperation(t *testing.T) {
 	oldPub, oldPriv, err := awid.GenerateKeypair()
 	if err != nil {

--- a/cli/go/cmd/aw/id_rotation_recovery_command_test.go
+++ b/cli/go/cmd/aw/id_rotation_recovery_command_test.go
@@ -319,13 +319,40 @@ func TestAwIDRotationRecoveryWithoutPendingStateStillRejectsIdentityKeyMismatch(
 		t.Fatal(err)
 	}
 
-	for _, action := range []string{"recover", "status"} {
-		cmd := exec.CommandContext(ctx, bin, "id", "rotate-key", action, "--json")
+	actions := []struct {
+		name string
+		args []string
+	}{
+		{name: "recover", args: []string{"recover"}},
+		{name: "status", args: []string{"status"}},
+		{name: "plain"},
+	}
+	for _, action := range actions {
+		args := append([]string{"id", "rotate-key"}, action.args...)
+		args = append(args, "--json")
+		cmd := exec.CommandContext(ctx, bin, args...)
 		cmd.Env = testCommandEnv(dir)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		if err == nil || !strings.Contains(string(out), "does not match .aw/signing.key") {
-			t.Fatalf("%s mismatch error=%v\n%s", action, err, out)
+			t.Fatalf("%s mismatch error=%v\n%s", action.name, err, out)
+		}
+	}
+	rotationDir := filepath.Join(dir, ".aw", "rotation")
+	pending, err := loadPendingRotationState(rotationDir, stableID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending != nil {
+		t.Fatalf("ordinary mismatched identity created pending operation: %+v", pending)
+	}
+	entries, err := os.ReadDir(filepath.Join(rotationDir, "pending"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".lock") {
+			t.Fatalf("ordinary mismatched identity created pending file: %s", entry.Name())
 		}
 	}
 }

--- a/cli/go/internal/crashtest/checkpoint.go
+++ b/cli/go/internal/crashtest/checkpoint.go
@@ -1,0 +1,62 @@
+// Package crashtest provides an inert-by-default process checkpoint used by
+// real-binary SIGKILL recovery tests. It is internal test instrumentation, not
+// production control flow.
+package crashtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const protocol = "aweb-internal-rotation-crash-test-v1"
+
+const (
+	protocolEnv     = "AWEB_INTERNAL_ROTATION_CRASH_TEST_PROTOCOL"
+	pointEnv        = "AWEB_INTERNAL_ROTATION_CRASH_TEST_POINT"
+	pathContainsEnv = "AWEB_INTERNAL_ROTATION_CRASH_TEST_PATH_CONTAINS"
+	readyFDEnv      = "AWEB_INTERNAL_ROTATION_CRASH_TEST_READY_FD"
+	controlFDEnv    = "AWEB_INTERNAL_ROTATION_CRASH_TEST_CONTROL_FD"
+)
+
+// Checkpoint notifies an inherited ready pipe and blocks on an inherited
+// control pipe only when the complete versioned test capability is present.
+// With the capability unset, malformed, or incomplete it returns immediately.
+func Checkpoint(point string, path ...string) {
+	if os.Getenv(protocolEnv) != protocol || os.Getenv(pointEnv) != point {
+		return
+	}
+	selector := filepath.ToSlash(strings.TrimSpace(os.Getenv(pathContainsEnv)))
+	if selector != "" {
+		if len(path) == 0 || !strings.Contains(filepath.ToSlash(path[0]), selector) {
+			return
+		}
+	}
+	readyFD, readyErr := inheritedFD(readyFDEnv)
+	controlFD, controlErr := inheritedFD(controlFDEnv)
+	if readyErr != nil || controlErr != nil || readyFD == controlFD {
+		return
+	}
+	ready := os.NewFile(uintptr(readyFD), "rotation-crash-ready")
+	control := os.NewFile(uintptr(controlFD), "rotation-crash-control")
+	if ready == nil || control == nil {
+		return
+	}
+	defer ready.Close()
+	defer control.Close()
+	if _, err := fmt.Fprintln(ready, point); err != nil {
+		return
+	}
+	var release [1]byte
+	_, _ = control.Read(release[:])
+}
+
+func inheritedFD(name string) (int, error) {
+	fd, err := strconv.Atoi(strings.TrimSpace(os.Getenv(name)))
+	if err != nil || fd < 3 {
+		return 0, fmt.Errorf("invalid inherited file descriptor")
+	}
+	return fd, nil
+}


### PR DESCRIPTION
## Summary
- recover a private-key-only active promotion and repair its public sibling
- run real CLI subprocesses through 14 reader-distinguishable crash states and send verified SIGKILL
- prove recovery preserves foreign operations and every APPLIED/UNKNOWN replacement key, converges key files/identity, and yields exactly one authoritative apply
- keep the inherited-pipe crash checkpoint inert unless its complete versioned capability is present

## Production mutation evidence
- each named checkpoint case RED independently while a neighboring case stayed GREEN (shared lines explicitly grouped)
- state-before-key, private-before-public (pending and archive), and active-private-before-public ordering mutations RED their partial-state cases
- old/new authoritative reconciliation branch mutations RED E/F independently
- split explicit entry, plain entry, and public repair mutations RED their focused guards
- incomplete protocol gate mutation RED the inert full-path guard while active checkpoint stayed GREEN
- no-pending recover/status validation mutations RED separately

## Validation
- `go test ./... -count=1` PASS
- `go test -race ./... -count=1` PASS
- Windows/386 and Linux/386 cmd/aw test cross-compiles PASS

Exact candidate: `f0e62dc285da992d76994cd588409c678d9c456b`