### PR TITLE
fix(cli): per-domain _awid discovery in recipient resolver (cross-registry sends)

### DIFF
--- a/cli/go/awid/registry_resolver.go
+++ b/cli/go/awid/registry_resolver.go
@@ -563,29 +563,43 @@ func (r *RegistryResolver) discoverRegistry(ctx context.Context, domain string) 
 }
 
 func (r *RegistryResolver) DiscoverRegistry(ctx context.Context, domain string) (string, error) {
-	if strings.TrimSpace(r.fallbackRegistryURL) != "" {
-		return r.fallbackRegistryURL, nil
-	}
 	return r.discoverRegistry(ctx, domain)
 }
 
 func (r *RegistryResolver) discoverAuthority(ctx context.Context, domain string) (DomainAuthority, error) {
 	domain = canonicalizeDomain(domain)
-	if strings.TrimSpace(r.fallbackRegistryURL) != "" {
-		return DomainAuthority{RegistryURL: r.fallbackRegistryURL}, nil
-	}
 	if cached, ok := r.loadRegistryCache(domain); ok {
 		return cached, nil
 	}
+	// fallbackRegistryURL (the identity's configured registry_url) is a FALLBACK,
+	// not a per-domain override: a domain that publishes an `_awid` record is
+	// authoritative for its own registry. Discovering per domain is what lets a
+	// sender and recipient in different registries each resolve against theirs
+	// in a single send (cross-registry federation).
+	fallback := strings.TrimSpace(r.fallbackRegistryURL)
 	authority, err := DiscoverAuthoritativeRegistry(ctx, r.DNSResolver, domain)
 	if err != nil {
+		// DNS discovery failed (network/DNS error). Fall back to the configured
+		// registry so offline/private deployments keep working; else surface it.
+		if fallback != "" {
+			return DomainAuthority{RegistryURL: fallback}, nil
+		}
 		return DomainAuthority{}, err
 	}
+	if strings.TrimSpace(authority.ControllerDID) == "" {
+		// No `_awid` record found for the domain or any ancestor. Prefer the
+		// explicitly configured fallback registry; otherwise the public default.
+		if fallback != "" {
+			authority.RegistryURL = fallback
+		} else if strings.TrimSpace(authority.RegistryURL) == "" {
+			authority.RegistryURL = DefaultAWIDRegistryURL
+		}
+		r.storeRegistryCache(domain, authority, registryDiscoveryTTL)
+		return authority, nil
+	}
+	// The domain published an authoritative `_awid` record: honour its registry.
 	if strings.TrimSpace(authority.RegistryURL) == "" {
 		authority.RegistryURL = DefaultAWIDRegistryURL
-	}
-	if r.fallbackRegistryURL != "" {
-		authority.RegistryURL = r.fallbackRegistryURL
 	}
 	r.storeRegistryCache(domain, authority, registryDiscoveryTTL)
 	return authority, nil


### PR DESCRIPTION
Fixes #30.

## Problem

`aw mail send` / `aw chat send` to a recipient in a **different registry** than the sender's cannot succeed. `RegistryResolver.discoverAuthority` treats the identity's configured `registry_url` (`fallbackRegistryURL`) as a **hard per-domain override**, returning it for every domain before `DiscoverAuthoritativeRegistry` (which already walks `_awid.<domain>` and returns the correct per-domain registry) is ever reached. `DiscoverRegistry` had the same early return.

Because `registry_url` from `identity.yaml` is always set, a single client registry can only ever satisfy the sender **or** the recipient:

- `registry_url` = sender's registry → recipient 404s (`Namespace not found`).
- `registry_url` = recipient's registry → sender 422s (`sender_address_did_mismatch`).

## Fix

Make `fallbackRegistryURL` a true fallback:

- run `_awid` DNS discovery first;
- honour the DNS-declared registry when the domain publishes an `_awid` record (this is what lets a sender and recipient in different registries each resolve against theirs in one send);
- use the configured `registry_url` only when discovery finds no record, and on a DNS error so offline/private deployments keep working.

Also drops the identical early-return in `DiscoverRegistry`. This mirrors the server-side `awid/src/awid/registry.py::_registry_url_for_domain`, which only short-circuits for a *local* registry and otherwise performs per-domain `discover_registry_override`.

## Verification

From a self-hosted `missionctrl.dev` sender (own awid, `registry_url = https://awid.missionctrl.dev`):

- Before: `aw mail send --to juan.aweb.ai/alice` → `404 Namespace not found` (queried our awid, which doesn't host juan.aweb.ai).
- After: `juan.aweb.ai/alice` resolves via `_awid.aweb.ai` → `api.awid.ai`, while `missionctrl.dev/*` still resolves via `_awid.missionctrl.dev` → our own awid. Sending to a DNS-backed recipient (`aweb.ai/athena`) now resolves, passes strict verification, and reaches federated delivery.
- `awid`, `cmd/aw`, and `conformance` Go test suites pass.

No dependency or API changes; single-file change to the resolver.